### PR TITLE
Migrate iOS app to generated Swift SDK

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		2052B7B0961EC927404CD8F1 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8267620B852D7914EAD83DAE /* SettingsView.swift */; };
 		22E710F949296F2C4F470275 /* AdminSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A1E349FB6E5B428703A548 /* AdminSectionView.swift */; };
 		238DBF144A2302C11DE50388 /* ChangePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7812397531D2CD01F4488BC6 /* ChangePasswordView.swift */; };
+		2765A46120FE03FEBFC1E7A5 /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = AAB8C31E7368B19A07AE1A3E /* OpenAPIURLSession */; };
 		28EDDF86319305C5ABC398D0 /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CFB90021A1428D8962F1BF /* Operations.swift */; };
 		2D8B1BCF039F334B0A7FD76A /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9415E01C2D644848CDBB4D0 /* Theme.swift */; };
 		2DDFD6ABC4E15C7FFF7C72C5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1164C99171DC47A99F71C0D /* Assets.xcassets */; };
@@ -41,18 +42,21 @@
 		397E6C46FAA21775D022DEA1 /* StagingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970FC2E2E5418295A48A9B0E /* StagingListView.swift */; };
 		3D57CDAFE896BFB0BB441D87 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72273F4294E6BC2DA2D09609 /* SearchView.swift */; };
 		3E092F89AC9B6CA6DC50DAEB /* RepositoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9688E0041F1683C5DDFA6071 /* RepositoriesView.swift */; };
+		3E86A76D6A7C20EB5128C9B9 /* SDKClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */; };
 		42DD12D515613DB543BCD922 /* TelemetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4252913A5015A9448F73683 /* TelemetryView.swift */; };
 		431F59BD5A02CA08C396903A /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73AE1952EFB3C338C7D0771 /* LoginView.swift */; };
 		475F7C0CA9365AB11D952814 /* ReplicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8067728F7917AD61F0DB4037 /* ReplicationView.swift */; };
 		47DFA7F8B01E5A21906642A2 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DDB4F8B15C1FB99A2843 /* Package.swift */; };
 		4BB5107B04DD21BF5EC76FB0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8267620B852D7914EAD83DAE /* SettingsView.swift */; };
 		4BE83BE4509F6A9FBAC7EA93 /* RepoSecurityConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746DB83A1B571F5CDFDD791E /* RepoSecurityConfigView.swift */; };
+		4F9A68618BD7C56914CA8D65 /* OpenAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 068276BAE547E09F546FF9A8 /* OpenAPIRuntime */; };
 		50E508B7E51DFFC65B9BCBCE /* PoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */; };
 		540BD81E8B758B26D1D5A040 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341E812182C7DEF2DE15BDE6 /* AuthManager.swift */; };
 		55D6428BD2147FDF7F9BA85A /* StagingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970FC2E2E5418295A48A9B0E /* StagingListView.swift */; };
 		55E48C58A4F43DC5DC868FE0 /* Promotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CA7F1FBDE367A6D4052F47 /* Promotion.swift */; };
 		576ECFCB3DD22323E6DF2217 /* RepositoryDetailTabbedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FEF3A0FA55ECC63DDC8899F /* RepositoryDetailTabbedView.swift */; };
 		596F4AA252F5DB25B76106B8 /* Sbom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF4F010E1DD1DC5415E7F11 /* Sbom.swift */; };
+		5A6DAF18D877C3CD3491EE83 /* OpenAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 97058A57D74CF527E5233E83 /* OpenAPIRuntime */; };
 		5B084A3BAB0EDDAFF19B81EF /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 1918E595B83245CF64AE0DB5 /* Dependencies */; };
 		5C6497F001D512DDC978EA47 /* UsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8761FACD0287EF99C0A1E50 /* UsersView.swift */; };
 		5E0D22452C4DCD3E0ECCEED2 /* Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA65CF7CCFDB01286A0C408 /* Integration.swift */; };
@@ -90,6 +94,7 @@
 		99FEE2AAD62A0388A67BF3C6 /* SSOView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C66794630C443427F1527 /* SSOView.swift */; };
 		9DE03A85868EB62612D588DC /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */; };
 		9F313A124D557820A4F7F737 /* RepoSecurityConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */; };
+		9FBBA3D5EAF49575952C78AD /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = F35A063FFE69F8B8A3CD7AEE /* OpenAPIURLSession */; };
 		ABC754B5DC49717B25A912DB /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59705D3B5F2000ACABB8A48 /* Auth.swift */; };
 		AF076028A446FB1E28446D96 /* DtDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59106973EB99FD9424D44224 /* DtDashboardView.swift */; };
 		AFDDA47CBD83C0460C150C5D /* MonitoringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F6787AE2A18008C8EA282F /* MonitoringView.swift */; };
@@ -110,15 +115,18 @@
 		C0067BC56E14F7597CD91596 /* IntegrationSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADAC51BA77982E3BBFB4403 /* IntegrationSectionView.swift */; };
 		C02053BA07DD2669117F0E0C /* StagingSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846E4EAE3F90ADE47BE07930 /* StagingSectionView.swift */; };
 		C0426BF8DC4EE20233E24AC4 /* PeersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F130C4E4EC403EC23594AE44 /* PeersView.swift */; };
+		C0DB34D8D07AFB6A08BE9C1F /* ArtifactKeeperClient in Frameworks */ = {isa = PBXBuildFile; productRef = BF71DF2B7D3220D7E6D30597 /* ArtifactKeeperClient */; };
 		C271C3B782A35CE71284249F /* Promotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CA7F1FBDE367A6D4052F47 /* Promotion.swift */; };
 		C42665F0C144A44BC7AAA95D /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15E45652EBB4DD2505127F /* WelcomeView.swift */; };
 		C485A2CE45918DADE34AAA1B /* SecurityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7351368D8EDB157E264ECBBC /* SecurityView.swift */; };
+		CB1B30416205DE75103AE1EC /* ArtifactKeeperClient in Frameworks */ = {isa = PBXBuildFile; productRef = 55A6201C43E26F452A85B4AC /* ArtifactKeeperClient */; };
 		CB9F64C28FEBB032DD2210F6 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FB2391848A9D7A02E4F7DC /* Repository.swift */; };
 		CBA92159E5A5DFC00F6CBC28 /* RepositoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9688E0041F1683C5DDFA6071 /* RepositoriesView.swift */; };
 		CE29910E19439190B021FD6B /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F86EB93D00E4631A8F8F9C /* Artifact.swift */; };
 		D11B924C3B8CFCE3F0E46905 /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */; };
 		D3653822D6C8332BC92D8642 /* SSOView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C66794630C443427F1527 /* SSOView.swift */; };
 		D36FF1BE98A8940CC8E38C27 /* DependencyTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */; };
+		D40943078196189E5E593C67 /* SDKClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */; };
 		D40F5A35411ACBE8737D54F7 /* ReplicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8067728F7917AD61F0DB4037 /* ReplicationView.swift */; };
 		D6794B241227A7A33DE011F3 /* ArtifactKeeperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D217BC8D6B2994A881C4E04E /* ArtifactKeeperApp.swift */; };
 		D7ED286EF2FA5A473F566856 /* StagingSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846E4EAE3F90ADE47BE07930 /* StagingSectionView.swift */; };
@@ -178,6 +186,7 @@
 		9050B925E8CDAB492ED01C01 /* AnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsView.swift; sourceTree = "<group>"; };
 		9688E0041F1683C5DDFA6071 /* RepositoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoriesView.swift; sourceTree = "<group>"; };
 		970FC2E2E5418295A48A9B0E /* StagingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagingListView.swift; sourceTree = "<group>"; };
+		974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKClient.swift; sourceTree = "<group>"; };
 		97C25FDC3175541D37A0EF96 /* ArtifactKeeper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ArtifactKeeper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A15E45652EBB4DD2505127F /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		9CBE59905B179E64919791A7 /* Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Admin.swift; sourceTree = "<group>"; };
@@ -214,6 +223,9 @@
 				B535272FD68109CDCE673AFC /* Alamofire in Frameworks */,
 				2E444BC52EC3271C8EC44E4D /* Kingfisher in Frameworks */,
 				B516A827540A1DDE26F2B9BA /* Dependencies in Frameworks */,
+				C0DB34D8D07AFB6A08BE9C1F /* ArtifactKeeperClient in Frameworks */,
+				4F9A68618BD7C56914CA8D65 /* OpenAPIRuntime in Frameworks */,
+				2765A46120FE03FEBFC1E7A5 /* OpenAPIURLSession in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -224,6 +236,9 @@
 				32C0A53DAE5CEA63670B57F2 /* Alamofire in Frameworks */,
 				94FC8121D7F395B27138FF6C /* Kingfisher in Frameworks */,
 				5B084A3BAB0EDDAFF19B81EF /* Dependencies in Frameworks */,
+				CB1B30416205DE75103AE1EC /* ArtifactKeeperClient in Frameworks */,
+				5A6DAF18D877C3CD3491EE83 /* OpenAPIRuntime in Frameworks */,
+				9FBBA3D5EAF49575952C78AD /* OpenAPIURLSession in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -384,13 +399,6 @@
 			path = Operations;
 			sourceTree = "<group>";
 		};
-		B569171887FEA5C430B3C5DE /* Components */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Components;
-			sourceTree = "<group>";
-		};
 		B996E356DE5DDBFB3D2557A2 /* Staging */ = {
 			isa = PBXGroup;
 			children = (
@@ -425,6 +433,7 @@
 			isa = PBXGroup;
 			children = (
 				3412EF9765589F0F5C9613ED /* APIClient.swift */,
+				974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */,
 				E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */,
 			);
 			path = API;
@@ -454,7 +463,6 @@
 			isa = PBXGroup;
 			children = (
 				E6A527DEEF9DECA3F2E8EC26 /* AccountToolbarModifier.swift */,
-				B569171887FEA5C430B3C5DE /* Components */,
 				AD6324D1245757CE4DC9A4F0 /* Theme */,
 			);
 			path = UI;
@@ -521,6 +529,9 @@
 				36656CBAF76FAB0F5ECC7855 /* Alamofire */,
 				3706EE4D071525F8E60A5A3B /* Kingfisher */,
 				1918E595B83245CF64AE0DB5 /* Dependencies */,
+				55A6201C43E26F452A85B4AC /* ArtifactKeeperClient */,
+				97058A57D74CF527E5233E83 /* OpenAPIRuntime */,
+				F35A063FFE69F8B8A3CD7AEE /* OpenAPIURLSession */,
 			);
 			productName = ArtifactKeeper_iOS;
 			productReference = DC2FE890E60756D1FFA94CD1 /* ArtifactKeeper.app */;
@@ -543,6 +554,9 @@
 				A0A50A1985B1B97F68A946DA /* Alamofire */,
 				9CEE3D545B740FE08259C18F /* Kingfisher */,
 				F1F1A51E9222F8A1C1F5C1EB /* Dependencies */,
+				BF71DF2B7D3220D7E6D30597 /* ArtifactKeeperClient */,
+				068276BAE547E09F546FF9A8 /* OpenAPIRuntime */,
+				AAB8C31E7368B19A07AE1A3E /* OpenAPIURLSession */,
 			);
 			productName = ArtifactKeeper_macOS;
 			productReference = 97C25FDC3175541D37A0EF96 /* ArtifactKeeper.app */;
@@ -570,7 +584,10 @@
 			packageReferences = (
 				35E6D2AC4A1155938881AA4F /* XCRemoteSwiftPackageReference "Alamofire" */,
 				38DE02D2EDBC7397FB53C39A /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				55BD8E155775DB2FFC028CE1 /* XCRemoteSwiftPackageReference "artifact-keeper-swift-sdk" */,
 				D467491AC25938924605717B /* XCRemoteSwiftPackageReference "swift-dependencies" */,
+				076178158F5A63B454FAF5D4 /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */,
+				734E1A5E4269B26A38FFE68C /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */,
 			);
 			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
@@ -648,6 +665,7 @@
 				CBA92159E5A5DFC00F6CBC28 /* RepositoriesView.swift in Sources */,
 				CB9F64C28FEBB032DD2210F6 /* Repository.swift in Sources */,
 				576ECFCB3DD22323E6DF2217 /* RepositoryDetailTabbedView.swift in Sources */,
+				D40943078196189E5E593C67 /* SDKClient.swift in Sources */,
 				D3653822D6C8332BC92D8642 /* SSOView.swift in Sources */,
 				B6A7958608DE308DD63F5435 /* Sbom.swift in Sources */,
 				7795B1C86E7E5530C0ECA6BE /* SbomView.swift in Sources */,
@@ -716,6 +734,7 @@
 				3E092F89AC9B6CA6DC50DAEB /* RepositoriesView.swift in Sources */,
 				DD14915474376F9ECAB7D78B /* Repository.swift in Sources */,
 				1EB081D63A5092425E75A0B0 /* RepositoryDetailTabbedView.swift in Sources */,
+				3E86A76D6A7C20EB5128C9B9 /* SDKClient.swift in Sources */,
 				99FEE2AAD62A0388A67BF3C6 /* SSOView.swift in Sources */,
 				596F4AA252F5DB25B76106B8 /* Sbom.swift in Sources */,
 				B85DD5AD52ECDF8AF03AD72F /* SbomView.swift in Sources */,
@@ -987,6 +1006,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		076178158F5A63B454FAF5D4 /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-openapi-runtime";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.7.0;
+			};
+		};
 		35E6D2AC4A1155938881AA4F /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
@@ -1003,6 +1030,22 @@
 				minimumVersion = 7.0.0;
 			};
 		};
+		55BD8E155775DB2FFC028CE1 /* XCRemoteSwiftPackageReference "artifact-keeper-swift-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/artifact-keeper/artifact-keeper-swift-sdk.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = "1.1.0-dev.1";
+			};
+		};
+		734E1A5E4269B26A38FFE68C /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-openapi-urlsession";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		D467491AC25938924605717B /* XCRemoteSwiftPackageReference "swift-dependencies" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies.git";
@@ -1014,6 +1057,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		068276BAE547E09F546FF9A8 /* OpenAPIRuntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 076178158F5A63B454FAF5D4 /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */;
+			productName = OpenAPIRuntime;
+		};
 		1918E595B83245CF64AE0DB5 /* Dependencies */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D467491AC25938924605717B /* XCRemoteSwiftPackageReference "swift-dependencies" */;
@@ -1029,6 +1077,16 @@
 			package = 38DE02D2EDBC7397FB53C39A /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
 		};
+		55A6201C43E26F452A85B4AC /* ArtifactKeeperClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 55BD8E155775DB2FFC028CE1 /* XCRemoteSwiftPackageReference "artifact-keeper-swift-sdk" */;
+			productName = ArtifactKeeperClient;
+		};
+		97058A57D74CF527E5233E83 /* OpenAPIRuntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 076178158F5A63B454FAF5D4 /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */;
+			productName = OpenAPIRuntime;
+		};
 		9CEE3D545B740FE08259C18F /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 38DE02D2EDBC7397FB53C39A /* XCRemoteSwiftPackageReference "Kingfisher" */;
@@ -1039,10 +1097,25 @@
 			package = 35E6D2AC4A1155938881AA4F /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
 		};
+		AAB8C31E7368B19A07AE1A3E /* OpenAPIURLSession */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 734E1A5E4269B26A38FFE68C /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */;
+			productName = OpenAPIURLSession;
+		};
+		BF71DF2B7D3220D7E6D30597 /* ArtifactKeeperClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 55BD8E155775DB2FFC028CE1 /* XCRemoteSwiftPackageReference "artifact-keeper-swift-sdk" */;
+			productName = ArtifactKeeperClient;
+		};
 		F1F1A51E9222F8A1C1F5C1EB /* Dependencies */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D467491AC25938924605717B /* XCRemoteSwiftPackageReference "swift-dependencies" */;
 			productName = Dependencies;
+		};
+		F35A063FFE69F8B8A3CD7AEE /* OpenAPIURLSession */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 734E1A5E4269B26A38FFE68C /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */;
+			productName = OpenAPIURLSession;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ArtifactKeeper/Sources/Core/API/SDKClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/SDKClient.swift
@@ -1,0 +1,127 @@
+import Foundation
+import ArtifactKeeperClient
+import OpenAPIRuntime
+import OpenAPIURLSession
+import HTTPTypes
+
+// MARK: - Bearer Auth Middleware
+
+/// Middleware that injects Bearer token into requests.
+struct BearerAuthMiddleware: ClientMiddleware {
+    var token: @Sendable () -> String?
+
+    func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var request = request
+        if let token = token() {
+            request.headerFields[.authorization] = "Bearer \(token)"
+        }
+        return try await next(request, body, baseURL)
+    }
+}
+
+// MARK: - SDK Client Wrapper
+
+/// Manages the generated OpenAPI SDK `Client` instance, allowing base URL changes
+/// and bearer-token injection.
+actor SDKClient {
+    static let shared = SDKClient()
+
+    private(set) var client: Client
+    private var serverURL: URL
+    private var _token: String?
+
+    /// Returns the current bearer token (thread-safe via actor).
+    var token: String? { _token }
+
+    init() {
+        let stored = UserDefaults.standard.string(forKey: APIClient.serverURLKey) ?? ""
+        let url = URL(string: stored) ?? URL(string: "http://localhost:8080")!
+        self.serverURL = url
+        self._token = nil
+
+        // Build initial client
+        self.client = SDKClient.makeClient(serverURL: url, tokenProvider: { nil })
+    }
+
+    func setToken(_ token: String?) {
+        self._token = token
+        rebuildClient()
+    }
+
+    func updateBaseURL(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        self.serverURL = url
+        rebuildClient()
+    }
+
+    func getBaseURL() -> URL {
+        serverURL
+    }
+
+    private func rebuildClient() {
+        let capturedToken = _token
+        self.client = SDKClient.makeClient(
+            serverURL: serverURL,
+            tokenProvider: { capturedToken }
+        )
+    }
+
+    private static func makeClient(
+        serverURL: URL,
+        tokenProvider: @escaping @Sendable () -> String?
+    ) -> Client {
+        let authMiddleware = BearerAuthMiddleware(token: tokenProvider)
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        let session = URLSession(
+            configuration: config,
+            delegate: SelfSignedCertDelegate(),
+            delegateQueue: nil
+        )
+        let transport = URLSessionTransport(configuration: .init(session: session))
+        return Client(
+            serverURL: serverURL,
+            transport: transport,
+            middlewares: [authMiddleware]
+        )
+    }
+}
+
+// MARK: - Self-Signed Cert Delegate (shared)
+
+/// URLSession delegate that accepts self-signed certificates for self-hosted servers.
+final class SelfSignedCertDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: serverTrust))
+    }
+}
+
+// MARK: - SDK Error Helpers
+
+/// Maps SDK operation errors to the app's APIError type.
+enum SDKError: LocalizedError {
+    case unexpectedResponse(String)
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unexpectedResponse(let msg): return "Unexpected response: \(msg)"
+        case .serverError(let msg): return msg
+        }
+    }
+}

--- a/ArtifactKeeper/Sources/Core/API/ServerManager.swift
+++ b/ArtifactKeeper/Sources/Core/API/ServerManager.swift
@@ -97,7 +97,10 @@ class ServerManager: ObservableObject {
 
     private func applyServer(_ server: SavedServer) {
         UserDefaults.standard.set(server.url, forKey: APIClient.serverURLKey)
-        Task { await APIClient.shared.updateBaseURL(server.url) }
+        Task {
+            await APIClient.shared.updateBaseURL(server.url)
+            // SDKClient is also updated via APIClient.updateBaseURL
+        }
     }
 
     // Migrate from old single-server storage

--- a/ArtifactKeeper/Sources/Core/Models/Auth.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Auth.swift
@@ -23,6 +23,24 @@ struct LoginResponse: Codable, Sendable {
         case totpRequired = "totp_required"
         case totpToken = "totp_token"
     }
+
+    init(
+        accessToken: String,
+        refreshToken: String,
+        expiresIn: Int,
+        tokenType: String,
+        mustChangePassword: Bool?,
+        totpRequired: Bool?,
+        totpToken: String?
+    ) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresIn = expiresIn
+        self.tokenType = tokenType
+        self.mustChangePassword = mustChangePassword
+        self.totpRequired = totpRequired
+        self.totpToken = totpToken
+    }
 }
 
 struct UserInfo: Codable, Sendable, Identifiable {
@@ -66,6 +84,11 @@ struct TotpSetupResponse: Codable, Sendable {
         case secret
         case qrCodeUrl = "qr_code_url"
     }
+
+    init(secret: String, qrCodeUrl: String) {
+        self.secret = secret
+        self.qrCodeUrl = qrCodeUrl
+    }
 }
 
 struct TotpEnableResponse: Codable, Sendable {
@@ -73,6 +96,10 @@ struct TotpEnableResponse: Codable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case backupCodes = "backup_codes"
+    }
+
+    init(backupCodes: [String]) {
+        self.backupCodes = backupCodes
     }
 }
 
@@ -120,6 +147,22 @@ struct ProfileResponse: Codable, Sendable {
         case displayName = "display_name"
         case isAdmin = "is_admin"
         case totpEnabled = "totp_enabled"
+    }
+
+    init(
+        id: String,
+        username: String,
+        email: String,
+        displayName: String?,
+        isAdmin: Bool,
+        totpEnabled: Bool
+    ) {
+        self.id = id
+        self.username = username
+        self.email = email
+        self.displayName = displayName
+        self.isAdmin = isAdmin
+        self.totpEnabled = totpEnabled
     }
 }
 

--- a/ArtifactKeeper/Sources/Core/Models/Promotion.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Promotion.swift
@@ -185,6 +185,22 @@ struct PromotionResponse: Codable, Sendable {
         case promotedPath = "promoted_path"
         case message, warnings
     }
+
+    init(
+        success: Bool,
+        artifactId: String,
+        targetRepoKey: String,
+        promotedPath: String?,
+        message: String?,
+        warnings: [String]?
+    ) {
+        self.success = success
+        self.artifactId = artifactId
+        self.targetRepoKey = targetRepoKey
+        self.promotedPath = promotedPath
+        self.message = message
+        self.warnings = warnings
+    }
 }
 
 struct BulkPromotionRequest: Encodable, Sendable {
@@ -211,6 +227,13 @@ struct BulkPromotionResult: Codable, Sendable {
         case success, message
         case promotedPath = "promoted_path"
     }
+
+    init(artifactId: String, success: Bool, message: String?, promotedPath: String?) {
+        self.artifactId = artifactId
+        self.success = success
+        self.message = message
+        self.promotedPath = promotedPath
+    }
 }
 
 struct BulkPromotionResponse: Codable, Sendable {
@@ -224,6 +247,13 @@ struct BulkPromotionResponse: Codable, Sendable {
         case totalSucceeded = "total_succeeded"
         case totalFailed = "total_failed"
         case results
+    }
+
+    init(totalRequested: Int, totalSucceeded: Int, totalFailed: Int, results: [BulkPromotionResult]) {
+        self.totalRequested = totalRequested
+        self.totalSucceeded = totalSucceeded
+        self.totalFailed = totalFailed
+        self.results = results
     }
 }
 
@@ -254,6 +284,32 @@ struct PromotionHistoryEntry: Codable, Identifiable, Sendable {
         case comment
         case wasForced = "was_forced"
         case promotedAt = "promoted_at"
+    }
+
+    init(
+        id: String,
+        artifactId: String,
+        artifactName: String,
+        artifactVersion: String?,
+        sourceRepoKey: String,
+        targetRepoKey: String,
+        promotedBy: String,
+        promotedByUsername: String?,
+        comment: String?,
+        wasForced: Bool,
+        promotedAt: String
+    ) {
+        self.id = id
+        self.artifactId = artifactId
+        self.artifactName = artifactName
+        self.artifactVersion = artifactVersion
+        self.sourceRepoKey = sourceRepoKey
+        self.targetRepoKey = targetRepoKey
+        self.promotedBy = promotedBy
+        self.promotedByUsername = promotedByUsername
+        self.comment = comment
+        self.wasForced = wasForced
+        self.promotedAt = promotedAt
     }
 }
 

--- a/ArtifactKeeper/Sources/Core/Models/Repository.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Repository.swift
@@ -22,6 +22,32 @@ struct Repository: Codable, Identifiable, Sendable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
     }
+
+    init(
+        id: String,
+        key: String,
+        name: String,
+        format: String,
+        repoType: String,
+        isPublic: Bool,
+        description: String?,
+        storageUsedBytes: Int64,
+        quotaBytes: Int64?,
+        createdAt: String,
+        updatedAt: String
+    ) {
+        self.id = id
+        self.key = key
+        self.name = name
+        self.format = format
+        self.repoType = repoType
+        self.isPublic = isPublic
+        self.description = description
+        self.storageUsedBytes = storageUsedBytes
+        self.quotaBytes = quotaBytes
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
 }
 
 struct RepositoryListResponse: Codable, Sendable {

--- a/ArtifactKeeper/Sources/Core/Models/VirtualMember.swift
+++ b/ArtifactKeeper/Sources/Core/Models/VirtualMember.swift
@@ -18,6 +18,24 @@ struct VirtualMember: Codable, Identifiable, Sendable {
         case priority
         case createdAt = "created_at"
     }
+
+    init(
+        id: String,
+        memberRepoId: String,
+        memberRepoKey: String,
+        memberRepoName: String,
+        memberRepoType: String,
+        priority: Int,
+        createdAt: String
+    ) {
+        self.id = id
+        self.memberRepoId = memberRepoId
+        self.memberRepoKey = memberRepoKey
+        self.memberRepoName = memberRepoName
+        self.memberRepoType = memberRepoType
+        self.priority = priority
+        self.createdAt = createdAt
+    }
 }
 
 struct VirtualMembersResponse: Codable, Sendable {

--- a/Info.plist
+++ b/Info.plist
@@ -22,15 +22,12 @@
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
-	<key>UILaunchScreen</key>
-	<dict>
-		<key>UIColorName</key>
-		<string>AccentColor</string>
-	</dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
 </dict>
 </plist>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f7ca3bda887edfd8074ea9a0e277db4b30f505d46b3167f7f9f2c5199cc6d567",
+  "originHash" : "b5006fe5fa104ef338c977b99b8d880902024afbf6b19fbb9057f3f7dcf6554c",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "3f99050e75bbc6fe71fc323adabb039756680016",
         "version" : "5.11.1"
+      }
+    },
+    {
+      "identity" : "artifact-keeper-swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/artifact-keeper/artifact-keeper-swift-sdk.git",
+      "state" : {
+        "revision" : "4b5ac6f33bba81744dc25659b4679aa3aea455a6",
+        "version" : "1.1.0-dev.1"
       }
     },
     {
@@ -29,12 +38,48 @@
       }
     },
     {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit",
+      "state" : {
+        "revision" : "343b2c1793058fcc53c1bd7e2907f8e3a4d640fb",
+        "version" : "3.9.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
       "identity" : "swift-clocks",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
         "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
         "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
       }
     },
     {
@@ -56,6 +101,51 @@
       }
     },
     {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-generator",
+      "state" : {
+        "revision" : "ecf21fdf08d4cf30ca506bb822f5fe580e090efb",
+        "version" : "1.10.4"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "7cdf33371bf89b23b9cf4fd3ce8d3c825c28fbe8",
+        "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-urlsession",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-urlsession",
+      "state" : {
+        "revision" : "279aa6b77be6aa842a4bf3c45fa79fa15edf3e07",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
@@ -71,6 +161,15 @@
       "state" : {
         "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
         "version" : "1.8.1"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
+        "version" : "6.2.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,9 @@ let package = Package(
         .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.9.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.0.0"),
+        .package(url: "https://github.com/artifact-keeper/artifact-keeper-swift-sdk.git", from: "1.1.0-dev.1"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.7.0"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -19,6 +22,9 @@ let package = Package(
                 "Alamofire",
                 "Kingfisher",
                 .product(name: "Dependencies", package: "swift-dependencies"),
+                .product(name: "ArtifactKeeperClient", package: "artifact-keeper-swift-sdk"),
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
             ],
             path: "ArtifactKeeper/Sources"
         ),

--- a/project.yml
+++ b/project.yml
@@ -17,6 +17,15 @@ packages:
   swift-dependencies:
     url: https://github.com/pointfreeco/swift-dependencies.git
     from: "1.0.0"
+  artifact-keeper-swift-sdk:
+    url: https://github.com/artifact-keeper/artifact-keeper-swift-sdk.git
+    from: "1.1.0-dev.1"
+  swift-openapi-runtime:
+    url: https://github.com/apple/swift-openapi-runtime
+    from: "1.7.0"
+  swift-openapi-urlsession:
+    url: https://github.com/apple/swift-openapi-urlsession
+    from: "1.0.0"
 
 targets:
   ArtifactKeeper:
@@ -44,10 +53,19 @@ targets:
       properties:
         CFBundleDisplayName: "Artifact Keeper"
         LSApplicationCategoryType: "public.app-category.developer-tools"
+        UILaunchScreen: {}
+        NSAppTransportSecurity:
+          NSAllowsLocalNetworking: true
     dependencies:
       - package: Alamofire
       - package: Kingfisher
       - package: swift-dependencies
         product: Dependencies
+      - package: artifact-keeper-swift-sdk
+        product: ArtifactKeeperClient
+      - package: swift-openapi-runtime
+        product: OpenAPIRuntime
+      - package: swift-openapi-urlsession
+        product: OpenAPIURLSession
     entitlements:
       path: ArtifactKeeper.entitlements


### PR DESCRIPTION
## Summary
- Replace 36 hand-written `APIClient` methods and ~80 manual `Codable` structs with the `ArtifactKeeperClient` Swift SDK generated from the OpenAPI spec
- SDK added as SPM dependency via `swift-openapi-generator` build plugin
- `SDKClient` actor wraps the generated `Client` with `BearerAuthMiddleware` for JWT injection
- `APIClient` kept as thin wrapper delegating to SDK, minimizing changes across 50+ SwiftUI views

## Changes
- **Added**: `SDKClient.swift` with bearer auth middleware and self-signed cert support
- **Migrated**: `APIClient.swift` to delegate through SDK client
- **Updated**: `AuthManager`, `ServerManager`, model files with SDK conversion initializers
- **Fixed**: `UILaunchScreen` in `Info.plist` for native iPhone resolution
- **Updated**: `project.yml` with SDK packages for xcodegen

## Test plan
- [ ] Xcode build passes (with Trust plugin prompt or \`-skipPackagePluginValidation\`)
- [ ] Login flow works on iOS 17 simulator
- [ ] Browse repositories, artifacts, packages
- [ ] Security, SBOM, and staging views load correctly
- [ ] Multi-server switching works

Closes #4