### PR TITLE
Add protobuf format to repository format list

### DIFF
--- a/ArtifactKeeper/Sources/Features/Repositories/RepositoriesView.swift
+++ b/ArtifactKeeper/Sources/Features/Repositories/RepositoriesView.swift
@@ -532,7 +532,7 @@ struct CreateRepositorySheet: View {
     private let apiClient = APIClient.shared
 
     private let repoTypes = ["local", "remote", "virtual"]
-    private let formats = ["generic", "docker", "maven", "npm", "pypi", "cargo", "nuget", "go", "helm", "rpm", "debian"]
+    private let formats = ["generic", "docker", "maven", "npm", "pypi", "cargo", "nuget", "go", "helm", "rpm", "debian", "protobuf"]
 
     private var isValid: Bool {
         !key.isEmpty && !name.isEmpty &&


### PR DESCRIPTION
## Summary
- Adds `"protobuf"` to the hardcoded formats array in RepositoriesView.swift

## Changes
- `ArtifactKeeper/Sources/Features/Repositories/RepositoriesView.swift` — added "protobuf" to formats array

## Test plan
- [ ] Verify protobuf appears in repository format picker