### PR TITLE
feat: add Incus/LXC to repository creation format list

### DIFF
--- a/ArtifactKeeper/Sources/Features/Repositories/RepositoriesView.swift
+++ b/ArtifactKeeper/Sources/Features/Repositories/RepositoriesView.swift
@@ -532,7 +532,7 @@ struct CreateRepositorySheet: View {
     private let apiClient = APIClient.shared
 
     private let repoTypes = ["local", "remote", "virtual"]
-    private let formats = ["generic", "docker", "maven", "npm", "pypi", "cargo", "nuget", "go", "helm", "rpm", "debian", "protobuf"]
+    private let formats = ["generic", "docker", "incus", "lxc", "maven", "npm", "pypi", "cargo", "nuget", "go", "helm", "rpm", "debian", "protobuf"]
 
     private var isValid: Bool {
         !key.isEmpty && !name.isEmpty &&


### PR DESCRIPTION
## Summary
- Add `incus` and `lxc` to the format picker in CreateRepositorySheet

Companion to backend PR: artifact-keeper/artifact-keeper#206

## Test plan
- [ ] Verify Incus and LXC appear in format picker when creating a repository