### PR TITLE
chore: add testing infrastructure and test plan

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @artifact-keeper/ios

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+<!-- What does this PR do and why? -->
+
+## Test Checklist
+- [ ] Unit tests added/updated
+- [ ] UI tests added/updated (if applicable)
+- [ ] Manually tested locally
+- [ ] No regressions in existing tests
+
+## Platform
+- [ ] Tested on iOS simulator
+- [ ] Tested on macOS
+- [ ] SwiftUI previews render correctly
+- [ ] Accessibility labels present on interactive elements
+- [ ] N/A - no UI changes

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,55 @@
+# iOS/macOS Test Plan
+
+## Overview
+
+The artifact-keeper iOS/macOS app uses SwiftUI with Swift 6 strict concurrency. Testing infrastructure is in early stages.
+
+## Test Inventory
+
+| Test Type | Framework | Count | CI Job | Status |
+|-----------|-----------|-------|--------|--------|
+| Build | swift build | Full app | `build` | Active |
+| Unit | XCTest | 1 stub | - | Stub only |
+| UI | XCUITest | 0 | - | Missing |
+| Snapshot | (none) | 0 | - | Missing |
+
+## How to Run
+
+### Build
+```bash
+swift build
+```
+
+### Unit Tests
+```bash
+swift test
+```
+
+### Generate Xcode Project (for UI tests)
+```bash
+xcodegen generate
+open ArtifactKeeper.xcodeproj
+# Run tests via Xcode: Cmd+U
+```
+
+## CI Pipeline
+
+```
+PR opened/pushed
+  -> build (swift build on macOS 15)
+
+Merge to main
+  -> build + nightly release (macOS + iOS simulator builds)
+
+Tag v*
+  -> archive + App Store upload
+```
+
+## Gaps and Roadmap
+
+| Gap | Recommendation | Priority |
+|-----|---------------|----------|
+| No real unit tests | Add XCTest cases for APIClient, AuthManager, data models | P1 |
+| No UI tests | Add XCUITest for login, browse, search flows | P2 |
+| No snapshot tests | Add swift-snapshot-testing for SwiftUI views | P3 |
+| No test CI job | Add `swift test` step to CI workflow | P1 |


### PR DESCRIPTION
## Summary
- Add CODEOWNERS for automatic PR review routing to the iOS team
- Add PR template with test checklist and platform section
- Add test plan documenting current state, how to run tests, and gaps

## Test plan
- [ ] Verify CODEOWNERS triggers review on next PR
- [ ] Verify PR template appears on new PRs