### PR TITLE
chore: exclude test files from SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=artifact-keeper_artifact-keeper-ios
+sonar.organization=artifact-keeper
+
+# Exclude test files from analysis
+sonar.exclusions=**/Tests/**


### PR DESCRIPTION
## Summary
- Adds sonar-project.properties to exclude Tests/ directory from SonarCloud analysis
- Prevents false-positive security hotspots from test fixture data

## Test plan
- [x] No functional changes, config-only