### PR TITLE
Add unit test job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,30 @@ jobs:
       - name: Build
         run: swift build
 
+  test:
+    name: Unit Tests
+    runs-on: macos-15
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s "$XCODE_PATH"
+
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-
+
+      - name: Run tests
+        run: swift test
+
   nightly:
     name: Nightly Release
     runs-on: macos-15
-    needs: [build]
+    needs: [build, test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds a dedicated Unit Tests job that runs `swift test` after build
- Nightly release now depends on both build and test passing
- Ensures the 128 unit tests added in #12 run on every PR and push to main

## Test plan
- [ ] CI pipeline runs build, then test in order
- [ ] Test failures block the nightly release job