### PR TITLE
Add SonarCloud scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Select Xcode
         run: sudo xcode-select -s "$XCODE_PATH"
@@ -86,6 +88,11 @@ jobs:
 
       - name: Run tests
         run: swift test
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   nightly:
     name: Nightly Release


### PR DESCRIPTION
## Summary

- Adds a SonarCloud scan step to the Unit Tests job in the CI workflow
- Uses `SonarSource/sonarqube-scan-action@v5` with the existing `sonar-project.properties` configuration
- Sets `fetch-depth: 0` on checkout for accurate git blame data

## Test plan

- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm SonarCloud picks up the scan after `SONAR_TOKEN` secret is configured