### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,127 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in the Artifact Keeper iOS/macOS app
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        If this is a **backend or API** issue, please file it in [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new).
+        If this is a **web UI** issue, please file it in [artifact-keeper-web](https://github.com/artifact-keeper/artifact-keeper-web/issues/new).
+
+        If you're not sure where the bug lives, go ahead and file it here. We'll move it to the right repo if needed.
+
+        For security vulnerabilities, please use [private security reporting](https://github.com/artifact-keeper/artifact-keeper-ios/security/advisories/new) instead of a public issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: Fill in the relevant details about your environment.
+      value: |
+        - Device: (e.g., iPhone 16, iPad Pro 13-inch, MacBook Pro M4)
+        - OS Version: (e.g., iOS 18.3, iPadOS 18.3, macOS 15.3)
+        - App Version: (e.g., 1.0.0)
+        - Xcode Version (if building from source): (e.g., 16.2)
+        - Network conditions: (e.g., Wi-Fi, cellular, VPN)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which platform are you running the app on?
+      options:
+        - iOS
+        - iPadOS
+        - macOS (Designed for iPad)
+        - macOS (Mac Catalyst)
+    validations:
+      required: true
+
+  - type: input
+    id: backend-version
+    attributes:
+      label: Backend Version
+      description: The version of the Artifact Keeper backend you are connecting to, if known.
+      placeholder: e.g., 1.1.0
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide a step-by-step list to reproduce the issue.
+      placeholder: |
+        1. Open the app
+        2. Navigate to ...
+        3. Tap on ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: crash-log
+    attributes:
+      label: Crash Log / Console Output
+      description: |
+        If the app crashed, include the crash log or relevant console output.
+        Tip: You can find crash logs in Settings > Privacy & Security > Analytics & Improvements > Analytics Data, or via the Crashes section in Xcode Organizer.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or Screen Recording
+      description: If applicable, attach screenshots or a screen recording to help illustrate the issue.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (e.g., happens only on first launch, only with certain server configurations, etc.).
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to verify this has not already been reported.
+          required: true
+        - label: I have redacted any sensitive information (tokens, passwords, server URLs) from logs and screenshots.
+          required: true
+        - label: I am using a supported version of the app and OS.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Backend / API Issues
+    url: https://github.com/artifact-keeper/artifact-keeper/issues/new
+    about: Report bugs or request features for the backend API and server
+  - name: Web UI Issues
+    url: https://github.com/artifact-keeper/artifact-keeper-web/issues/new
+    about: Report bugs or request features for the web frontend
+  - name: Security Vulnerability
+    url: https://github.com/artifact-keeper/artifact-keeper-ios/security/advisories/new
+    about: Please report security vulnerabilities privately through GitHub Security Advisories
+  - name: GitHub Discussions
+    url: https://github.com/orgs/artifact-keeper/discussions
+    about: Ask questions and discuss ideas with the community
+  - name: Documentation
+    url: https://artifactkeeper.com/docs
+    about: Browse the official documentation

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,58 @@
+name: Documentation Issue
+description: Report an issue with documentation or suggest improvements
+labels: ["documentation", "needs-triage"]
+body:
+  - type: dropdown
+    id: documentation-type
+    attributes:
+      label: Documentation Type
+      description: What kind of documentation issue is this?
+      options:
+        - Missing documentation
+        - Incorrect or outdated information
+        - Unclear or confusing content
+        - Typo or formatting issue
+        - Missing examples
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Where is the documentation issue? Provide a link, file path, or description of where you encountered it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the documentation issue in detail.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-improvement
+    attributes:
+      label: Suggested Improvement
+      description: If you have a suggestion for how to fix or improve the documentation, describe it here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context that might help (e.g., which version of the app or docs you were using).
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to verify this has not already been reported.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,93 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for the Artifact Keeper iOS/macOS app
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+
+        If this feature relates to the **backend or API**, please file it in [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new).
+
+        If you're not sure which repo the feature belongs in, go ahead and file it here. We'll move it if needed.
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: Describe the problem or limitation you are experiencing. What is frustrating or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe what you would like to happen. How should the feature work from a user's perspective?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe the specific scenario or workflow where this feature would be useful.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which platform(s) does this feature apply to?
+      options:
+        - iOS
+        - iPadOS
+        - macOS
+        - All platforms
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the app does this feature relate to?
+      options:
+        - Artifacts Browser
+        - Integration
+        - Security / Scanning
+        - Operations
+        - Administration
+        - Notifications
+        - Widgets
+        - Shortcuts / Automation
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or references that help explain the feature request.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to verify this has not already been requested.
+          required: true
+        - label: I have reviewed the documentation to confirm this feature does not already exist.
+          required: true


### PR DESCRIPTION
## Summary

- Add structured GitHub issue templates for bug reports, feature requests, and documentation issues
- Bug report template includes iOS/macOS-specific fields: device, OS version, platform selector (iOS, iPadOS, macOS Designed for iPad, Mac Catalyst), crash log collection tips, and environment details
- Feature request template includes component selector aligned with the app's five-section tab bar (Artifacts Browser, Integration, Security / Scanning, Operations, Administration) plus Widgets and Shortcuts
- Documentation issue template covers missing, outdated, unclear, or incorrectly formatted docs
- Config file enables blank issues and adds contact links directing users to the correct repo (backend, web, security advisories, discussions, docs site)

## Test plan

- [ ] Navigate to https://github.com/artifact-keeper/artifact-keeper-ios/issues/new/choose and verify all three templates appear
- [ ] Verify the contact links section renders correctly with links to backend, web, security, discussions, and docs
- [ ] Open each template form and confirm all fields render with correct labels, placeholders, and validation
- [ ] Submit a test issue using the bug report template and verify labels are applied
- [ ] Confirm blank issue creation still works