### PR TITLE
fix(security): make TLS certificate bypass opt-in via UserDefaults

### DIFF
--- a/ArtifactKeeper/Sources/Core/API/SDKClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/SDKClient.swift
@@ -95,7 +95,9 @@ actor SDKClient {
 
 // MARK: - Self-Signed Cert Delegate (shared)
 
-/// URLSession delegate that accepts self-signed certificates for self-hosted servers.
+/// URLSession delegate that supports self-signed certificates for self-hosted servers.
+/// By default uses standard TLS verification. Set the `trustSelfSignedCertificates`
+/// UserDefaults key to true to opt in to accepting self-signed certificates.
 final class SelfSignedCertDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
     func urlSession(
         _ session: URLSession,
@@ -107,7 +109,18 @@ final class SelfSignedCertDelegate: NSObject, URLSessionDelegate, @unchecked Sen
             completionHandler(.performDefaultHandling, nil)
             return
         }
-        completionHandler(.useCredential, URLCredential(trust: serverTrust))
+        let trustSelfSigned = UserDefaults.standard.bool(forKey: "trustSelfSignedCertificates")
+        guard trustSelfSigned else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        var error: CFError?
+        let trusted = SecTrustEvaluateWithError(serverTrust, &error)
+        if trusted || error != nil {
+            completionHandler(.useCredential, URLCredential(trust: serverTrust))
+        } else {
+            completionHandler(.performDefaultHandling, nil)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- `SelfSignedCertDelegate` now checks `UserDefaults.standard.bool(forKey: "trustSelfSignedCertificates")` (default: false)
- When disabled: standard TLS verification via `.performDefaultHandling`
- When enabled: `SecTrustEvaluateWithError` called before accepting

Previously all TLS certificate validation was unconditionally bypassed for all connections.

## Test plan
- [ ] App connects to properly-signed servers without toggle
- [ ] App rejects self-signed servers without toggle
- [ ] App connects to self-signed servers with toggle enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)