### PR TITLE
chore: update Swift SDK to v1.1.0

### DIFF
--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -403,7 +403,7 @@ actor APIClient {
             path: .init(key: repoKey)
         )
         let data = try response.ok.body.json
-        return data.items.map { m in
+        return data.members.map { m in
             VirtualMember(
                 id: m.id,
                 memberRepoId: m.member_repo_id,

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b5006fe5fa104ef338c977b99b8d880902024afbf6b19fbb9057f3f7dcf6554c",
+  "originHash" : "f42a4447d35470758cb65abbe2b4a832bc27aa064281212d34b789c6d03854e4",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/artifact-keeper/artifact-keeper-swift-sdk.git",
       "state" : {
-        "revision" : "4b5ac6f33bba81744dc25659b4679aa3aea455a6",
-        "version" : "1.1.0-dev.1"
+        "revision" : "3906e41db860c3c25d673fbf47619e2cb3058442",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.9.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.0.0"),
-        .package(url: "https://github.com/artifact-keeper/artifact-keeper-swift-sdk.git", from: "1.1.0-dev.1"),
+        .package(url: "https://github.com/artifact-keeper/artifact-keeper-swift-sdk.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.7.0"),
         .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
     ],


### PR DESCRIPTION
Updates artifact-keeper-swift-sdk from 1.1.0-dev.1 to 1.1.0. Fixes breaking change: VirtualMembersListResponse.items renamed to .members.