### PR TITLE
fix: route profile tokens to 1.2.1 API paths

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -21,9 +21,11 @@
 		0FAD280684B34F3ABB6306F5 /* Security.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D8118DAD8066C9D0EED317C /* Security.swift */; };
 		11ADAFBA69061A50ABECD77C /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155377690C14964BAFBAF481 /* ProfileView.swift */; };
 		129B0BFC5316B0B5D0353E96 /* PromotionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F34D6E71603103BC21FD8EA /* PromotionSheet.swift */; };
+		1364B70A29503AEFDA4B3FB5 /* SetupInstructionsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F4BB814BCEC4170B1CA727 /* SetupInstructionsViewTests.swift */; };
 		145F250E51703B74FF907E4A /* PromotionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFEA6435742230170CF65E1 /* PromotionHistoryView.swift */; };
 		152D6AC4ACB54B60335AAA44 /* TelemetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4252913A5015A9448F73683 /* TelemetryView.swift */; };
 		17488E98D524FCAB892BAAC5 /* ArtifactKeeperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A1761272FDDB00A7D41243 /* ArtifactKeeperTests.swift */; };
+		189014CE0807785BF1C97AF6 /* APIClientNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */; };
 		1AB249F434755BECF4124CA8 /* SetupInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113DC09E3B0845FAD9BDA8F6 /* SetupInstructionsView.swift */; };
 		1EB081D63A5092425E75A0B0 /* RepositoryDetailTabbedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FEF3A0FA55ECC63DDC8899F /* RepositoryDetailTabbedView.swift */; };
 		2052B7B0961EC927404CD8F1 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8267620B852D7914EAD83DAE /* SettingsView.swift */; };
@@ -39,6 +41,7 @@
 		2E5EA6194F309490D85C7FF9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1164C99171DC47A99F71C0D /* Assets.xcassets */; };
 		2EE7333E8775B1BB8124E0B7 /* Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA65CF7CCFDB01286A0C408 /* Integration.swift */; };
 		32C0A53DAE5CEA63670B57F2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 36656CBAF76FAB0F5ECC7855 /* Alamofire */; };
+		3366AEE087831CF15004691F /* DashboardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */; };
 		363B3E9588A4895C999757BC /* PackagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C67E4A61ED479E094891F7 /* PackagesView.swift */; };
 		389A90FAD7E4FDA7B8464B92 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73AE1952EFB3C338C7D0771 /* LoginView.swift */; };
 		38E52404189326A2143B485E /* ArtifactsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E44194ACD18BA49B67189B /* ArtifactsSectionView.swift */; };
@@ -53,6 +56,7 @@
 		47DFA7F8B01E5A21906642A2 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DDB4F8B15C1FB99A2843 /* Package.swift */; };
 		4BB5107B04DD21BF5EC76FB0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8267620B852D7914EAD83DAE /* SettingsView.swift */; };
 		4BE83BE4509F6A9FBAC7EA93 /* RepoSecurityConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746DB83A1B571F5CDFDD791E /* RepoSecurityConfigView.swift */; };
+		4EAE9C1A06FF203ED9F5CC77 /* TOTPVerificationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */; };
 		4F9A68618BD7C56914CA8D65 /* OpenAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 068276BAE547E09F546FF9A8 /* OpenAPIRuntime */; };
 		50E508B7E51DFFC65B9BCBCE /* PoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */; };
 		540BD81E8B758B26D1D5A040 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341E812182C7DEF2DE15BDE6 /* AuthManager.swift */; };
@@ -75,8 +79,11 @@
 		64C2073204C6C5D5B1248E52 /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CFB90021A1428D8962F1BF /* Operations.swift */; };
 		653D84744E6345714FCE559A /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84212AD84A94810D2C23339 /* AuthManagerTests.swift */; };
 		66342C499ECF4ADDCCF83FFC /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341E812182C7DEF2DE15BDE6 /* AuthManager.swift */; };
+		67018A342717D2F56ADA6F58 /* TOTPVerificationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */; };
+		6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */; };
 		706149420AF74CC3C2F55FDB /* PoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */; };
 		71DE9560CF0DC604499711B9 /* ServerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */; };
+		738EFB98489D855A1E2FFE8B /* SetupInstructionsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F4BB814BCEC4170B1CA727 /* SetupInstructionsViewTests.swift */; };
 		76A035773BD7C7A5065F5E65 /* ServerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */; };
 		7795B1C86E7E5530C0ECA6BE /* SbomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACFAEE53DF20945E710A82E /* SbomView.swift */; };
 		78A16F7733A939DF72627EAA /* OperationsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6A94422BAD7B966077C0D9 /* OperationsSectionView.swift */; };
@@ -91,6 +98,7 @@
 		83D01D48B7B7C3739E1344B3 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942CFADFFB28FA592F32CAB1 /* ModelTests.swift */; };
 		850750014FDAA447F7FEAA6A /* SecuritySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD29BEA4F2708262CE34F2E3 /* SecuritySectionView.swift */; };
 		859514D003E6E75A90E88192 /* UsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8761FACD0287EF99C0A1E50 /* UsersView.swift */; };
+		85BE46E9B704E5E25509D2FC /* APIClientExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */; };
 		85BE9083FC33581A5290D269 /* SecuritySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD29BEA4F2708262CE34F2E3 /* SecuritySectionView.swift */; };
 		87DFC05DFE36A27A9C5769A6 /* EditRepositorySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0896BDB350847081B1C7EA3 /* EditRepositorySheet.swift */; };
 		8D14D0F52AF6E89139D3264B /* RepoUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C1CC3C4956018E653EC486 /* RepoUploadView.swift */; };
@@ -104,10 +112,12 @@
 		95AFE5BD66F78CB88FB2ABA1 /* PeersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F130C4E4EC403EC23594AE44 /* PeersView.swift */; };
 		9770642EBFBB24D77727C5B5 /* TOTPVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB4EEF15843269173A9B772 /* TOTPVerificationView.swift */; };
 		983F1AE2C41B80CC7F6F9577 /* OperationsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6A94422BAD7B966077C0D9 /* OperationsSectionView.swift */; };
+		99C3358F603E8600CA038F75 /* DashboardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */; };
 		99FEE2AAD62A0388A67BF3C6 /* SSOView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C66794630C443427F1527 /* SSOView.swift */; };
 		9DE03A85868EB62612D588DC /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */; };
 		9F313A124D557820A4F7F737 /* RepoSecurityConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */; };
 		9FBBA3D5EAF49575952C78AD /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = F35A063FFE69F8B8A3CD7AEE /* OpenAPIURLSession */; };
+		A1A538DE905D6AF031923CF5 /* AuthManagerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */; };
 		ABC754B5DC49717B25A912DB /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59705D3B5F2000ACABB8A48 /* Auth.swift */; };
 		AD2DBF5F7973BE47E351CC36 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1901D688CCAD3DE71AA681AC /* APIClientTests.swift */; };
 		AF076028A446FB1E28446D96 /* DtDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59106973EB99FD9424D44224 /* DtDashboardView.swift */; };
@@ -157,8 +167,12 @@
 		EA935E6E499F8A518FCBA8C3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3E2D65A21BA60C8957EE36 /* ContentView.swift */; };
 		EAC22A0EE22A2528BABD2C6B /* Build.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90190CE35DA804C357A5FFDB /* Build.swift */; };
 		EBBA4D16B78FD192D954563C /* BuildsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E5BB60BE578603D5B6925 /* BuildsView.swift */; };
+		ECE469E91BEE0E35EB258F98 /* KeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */; };
+		EDB2B15C2187E730405D2B4F /* APIClientExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */; };
 		F37EAD999EEE9694758BBE8D /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15E45652EBB4DD2505127F /* WelcomeView.swift */; };
+		F5CE55686817D88933AC4AC1 /* AuthManagerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */; };
 		F790A545605AFA178BEEA506 /* WebhooksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8063DEF3B0228C26496797B7 /* WebhooksView.swift */; };
+		FB1F242DC31148C08DA16397 /* APIClientNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */; };
 		FCA0BB626B22F06543044B90 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9050B925E8CDAB492ED01C01 /* AnalyticsView.swift */; };
 		FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942CFADFFB28FA592F32CAB1 /* ModelTests.swift */; };
 		FDD83FAF91847C130D24C7ED /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79512BEEB0DBDA10DFDCFAAC /* MainTabView.swift */; };
@@ -197,15 +211,18 @@
 		38E44194ACD18BA49B67189B /* ArtifactsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactsSectionView.swift; sourceTree = "<group>"; };
 		3ADAC51BA77982E3BBFB4403 /* IntegrationSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationSectionView.swift; sourceTree = "<group>"; };
 		3D8118DAD8066C9D0EED317C /* Security.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Security.swift; sourceTree = "<group>"; };
+		3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPVerificationViewTests.swift; sourceTree = "<group>"; };
 		43C4236474392052DD29004F /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		4F60553EA149CE733245164B /* StagingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagingDetailView.swift; sourceTree = "<group>"; };
 		5897003BAFB18AFF0865CCEC /* VirtualMembersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMembersView.swift; sourceTree = "<group>"; };
+		58F4BB814BCEC4170B1CA727 /* SetupInstructionsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupInstructionsViewTests.swift; sourceTree = "<group>"; };
 		59106973EB99FD9424D44224 /* DtDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DtDashboardView.swift; sourceTree = "<group>"; };
 		59F86EB93D00E4631A8F8F9C /* Artifact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artifact.swift; sourceTree = "<group>"; };
 		5B3E2D65A21BA60C8957EE36 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		5B6A94422BAD7B966077C0D9 /* OperationsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationsSectionView.swift; sourceTree = "<group>"; };
 		5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensePoliciesView.swift; sourceTree = "<group>"; };
 		65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerManagerTests.swift; sourceTree = "<group>"; };
+		71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientExtendedTests.swift; sourceTree = "<group>"; };
 		72273F4294E6BC2DA2D09609 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		7351368D8EDB157E264ECBBC /* SecurityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityView.swift; sourceTree = "<group>"; };
 		746DB83A1B571F5CDFDD791E /* RepoSecurityConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSecurityConfigView.swift; sourceTree = "<group>"; };
@@ -213,6 +230,7 @@
 		76C1CC3C4956018E653EC486 /* RepoUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoUploadView.swift; sourceTree = "<group>"; };
 		7812397531D2CD01F4488BC6 /* ChangePasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangePasswordView.swift; sourceTree = "<group>"; };
 		783C66794630C443427F1527 /* SSOView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSOView.swift; sourceTree = "<group>"; };
+		785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientNetworkTests.swift; sourceTree = "<group>"; };
 		79512BEEB0DBDA10DFDCFAAC /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		7FEF3A0FA55ECC63DDC8899F /* RepositoryDetailTabbedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailTabbedView.swift; sourceTree = "<group>"; };
 		8063DEF3B0228C26496797B7 /* WebhooksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhooksView.swift; sourceTree = "<group>"; };
@@ -221,6 +239,7 @@
 		8343AC1EF5CDAEE5D335C0F0 /* ArtifactKeeperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArtifactKeeperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		846E4EAE3F90ADE47BE07930 /* StagingSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagingSectionView.swift; sourceTree = "<group>"; };
 		85C67E4A61ED479E094891F7 /* PackagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackagesView.swift; sourceTree = "<group>"; };
+		888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewTests.swift; sourceTree = "<group>"; };
 		8DF4F010E1DD1DC5415E7F11 /* Sbom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sbom.swift; sourceTree = "<group>"; };
 		8F34D6E71603103BC21FD8EA /* PromotionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionSheet.swift; sourceTree = "<group>"; };
 		90190CE35DA804C357A5FFDB /* Build.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Build.swift; sourceTree = "<group>"; };
@@ -232,6 +251,7 @@
 		97C25FDC3175541D37A0EF96 /* ArtifactKeeper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ArtifactKeeper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A15E45652EBB4DD2505127F /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		9CBE59905B179E64919791A7 /* Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Admin.swift; sourceTree = "<group>"; };
+		AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManagerTests.swift; sourceTree = "<group>"; };
 		AACFAEE53DF20945E710A82E /* SbomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SbomView.swift; sourceTree = "<group>"; };
 		ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSecurityConfig.swift; sourceTree = "<group>"; };
 		B1164C99171DC47A99F71C0D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -250,6 +270,7 @@
 		E6A527DEEF9DECA3F2E8EC26 /* AccountToolbarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountToolbarModifier.swift; sourceTree = "<group>"; };
 		E81FFEFE5A4DE0397D840007 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		E8A1E349FB6E5B428703A548 /* AdminSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminSectionView.swift; sourceTree = "<group>"; };
+		E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerExtendedTests.swift; sourceTree = "<group>"; };
 		ECFEA6435742230170CF65E1 /* PromotionHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionHistoryView.swift; sourceTree = "<group>"; };
 		F0896BDB350847081B1C7EA3 /* EditRepositorySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRepositorySheet.swift; sourceTree = "<group>"; };
 		F130C4E4EC403EC23594AE44 /* PeersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeersView.swift; sourceTree = "<group>"; };
@@ -324,11 +345,18 @@
 		07B050DA9AD07644F64AE3E0 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */,
+				785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */,
 				1901D688CCAD3DE71AA681AC /* APIClientTests.swift */,
 				C8A1761272FDDB00A7D41243 /* ArtifactKeeperTests.swift */,
+				E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */,
 				F84212AD84A94810D2C23339 /* AuthManagerTests.swift */,
+				888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */,
+				AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */,
 				942CFADFFB28FA592F32CAB1 /* ModelTests.swift */,
 				65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */,
+				58F4BB814BCEC4170B1CA727 /* SetupInstructionsViewTests.swift */,
+				3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */,
 			);
 			name = Tests;
 			path = ArtifactKeeper/Tests;
@@ -672,9 +700,10 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = 904A7BA2B99469CCC78D81AB /* Build configuration list for PBXProject "ArtifactKeeper" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -692,6 +721,7 @@
 				734E1A5E4269B26A38FFE68C /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 45729B00F0C5F9D207D341BC /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -727,11 +757,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				85BE46E9B704E5E25509D2FC /* APIClientExtendedTests.swift in Sources */,
+				FB1F242DC31148C08DA16397 /* APIClientNetworkTests.swift in Sources */,
 				AD2DBF5F7973BE47E351CC36 /* APIClientTests.swift in Sources */,
 				571951B0A6024875CE31B544 /* ArtifactKeeperTests.swift in Sources */,
+				A1A538DE905D6AF031923CF5 /* AuthManagerExtendedTests.swift in Sources */,
 				43CD93CC42B93AE1999FA8B9 /* AuthManagerTests.swift in Sources */,
+				99C3358F603E8600CA038F75 /* DashboardViewTests.swift in Sources */,
+				ECE469E91BEE0E35EB258F98 /* KeychainManagerTests.swift in Sources */,
 				FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */,
 				71DE9560CF0DC604499711B9 /* ServerManagerTests.swift in Sources */,
+				1364B70A29503AEFDA4B3FB5 /* SetupInstructionsViewTests.swift in Sources */,
+				4EAE9C1A06FF203ED9F5CC77 /* TOTPVerificationViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -812,11 +849,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EDB2B15C2187E730405D2B4F /* APIClientExtendedTests.swift in Sources */,
+				189014CE0807785BF1C97AF6 /* APIClientNetworkTests.swift in Sources */,
 				7B983BDEC8F0E8548B9E7E5E /* APIClientTests.swift in Sources */,
 				17488E98D524FCAB892BAAC5 /* ArtifactKeeperTests.swift in Sources */,
+				F5CE55686817D88933AC4AC1 /* AuthManagerExtendedTests.swift in Sources */,
 				653D84744E6345714FCE559A /* AuthManagerTests.swift in Sources */,
+				3366AEE087831CF15004691F /* DashboardViewTests.swift in Sources */,
+				6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */,
 				83D01D48B7B7C3739E1344B3 /* ModelTests.swift in Sources */,
 				76A035773BD7C7A5065F5E65 /* ServerManagerTests.swift in Sources */,
+				738EFB98489D855A1E2FFE8B /* SetupInstructionsViewTests.swift in Sources */,
+				67018A342717D2F56ADA6F58 /* TOTPVerificationViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -914,6 +958,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -987,6 +1032,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1116,6 +1162,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1158,6 +1205,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		D40943078196189E5E593C67 /* SDKClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */; };
 		D40F5A35411ACBE8737D54F7 /* ReplicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8067728F7917AD61F0DB4037 /* ReplicationView.swift */; };
 		D6794B241227A7A33DE011F3 /* ArtifactKeeperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D217BC8D6B2994A881C4E04E /* ArtifactKeeperApp.swift */; };
+		D6F8DEBE6DBFB0A7A1F1EB1F /* APIPathRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */; };
 		D7AD6E41B44AF34DF7994C57 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81FFEFE5A4DE0397D840007 /* KeychainManager.swift */; };
 		D7ED286EF2FA5A473F566856 /* StagingSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846E4EAE3F90ADE47BE07930 /* StagingSectionView.swift */; };
 		D8EFAA62D159A5DD32A18FC2 /* TOTPVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB4EEF15843269173A9B772 /* TOTPVerificationView.swift */; };
@@ -172,6 +173,7 @@
 		F37EAD999EEE9694758BBE8D /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15E45652EBB4DD2505127F /* WelcomeView.swift */; };
 		F5CE55686817D88933AC4AC1 /* AuthManagerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */; };
 		F790A545605AFA178BEEA506 /* WebhooksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8063DEF3B0228C26496797B7 /* WebhooksView.swift */; };
+		FABB8132DF5CEA339A9B769A /* APIPathRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */; };
 		FB1F242DC31148C08DA16397 /* APIClientNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */; };
 		FCA0BB626B22F06543044B90 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9050B925E8CDAB492ED01C01 /* AnalyticsView.swift */; };
 		FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942CFADFFB28FA592F32CAB1 /* ModelTests.swift */; };
@@ -272,6 +274,7 @@
 		E8A1E349FB6E5B428703A548 /* AdminSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminSectionView.swift; sourceTree = "<group>"; };
 		E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerExtendedTests.swift; sourceTree = "<group>"; };
 		ECFEA6435742230170CF65E1 /* PromotionHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionHistoryView.swift; sourceTree = "<group>"; };
+		EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPathRegressionTests.swift; sourceTree = "<group>"; };
 		F0896BDB350847081B1C7EA3 /* EditRepositorySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRepositorySheet.swift; sourceTree = "<group>"; };
 		F130C4E4EC403EC23594AE44 /* PeersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeersView.swift; sourceTree = "<group>"; };
 		F73AE1952EFB3C338C7D0771 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -348,6 +351,7 @@
 				71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */,
 				785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */,
 				1901D688CCAD3DE71AA681AC /* APIClientTests.swift */,
+				EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */,
 				C8A1761272FDDB00A7D41243 /* ArtifactKeeperTests.swift */,
 				E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */,
 				F84212AD84A94810D2C23339 /* AuthManagerTests.swift */,
@@ -760,6 +764,7 @@
 				85BE46E9B704E5E25509D2FC /* APIClientExtendedTests.swift in Sources */,
 				FB1F242DC31148C08DA16397 /* APIClientNetworkTests.swift in Sources */,
 				AD2DBF5F7973BE47E351CC36 /* APIClientTests.swift in Sources */,
+				D6F8DEBE6DBFB0A7A1F1EB1F /* APIPathRegressionTests.swift in Sources */,
 				571951B0A6024875CE31B544 /* ArtifactKeeperTests.swift in Sources */,
 				A1A538DE905D6AF031923CF5 /* AuthManagerExtendedTests.swift in Sources */,
 				43CD93CC42B93AE1999FA8B9 /* AuthManagerTests.swift in Sources */,
@@ -852,6 +857,7 @@
 				EDB2B15C2187E730405D2B4F /* APIClientExtendedTests.swift in Sources */,
 				189014CE0807785BF1C97AF6 /* APIClientNetworkTests.swift in Sources */,
 				7B983BDEC8F0E8548B9E7E5E /* APIClientTests.swift in Sources */,
+				FABB8132DF5CEA339A9B769A /* APIPathRegressionTests.swift in Sources */,
 				17488E98D524FCAB892BAAC5 /* ArtifactKeeperTests.swift in Sources */,
 				F5CE55686817D88933AC4AC1 /* AuthManagerExtendedTests.swift in Sources */,
 				653D84744E6345714FCE559A /* AuthManagerTests.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -320,45 +320,111 @@ actor APIClient {
         )
     }
 
-    // MARK: API Keys (profile endpoints not in SDK, kept as raw requests)
+    // MARK: API Tokens (unified 1.2.1 surface)
+    //
+    // 1.2.1 removed /api/v1/profile/api-keys and /profile/access-tokens in favor of a
+    // single token API. Listing is per user (/api/v1/users/{id}/tokens), create is
+    // /api/v1/auth/tokens, delete is /api/v1/auth/tokens/{token_id}. The two Profile
+    // tabs (API keys, access tokens) both map onto this one surface; responses are
+    // adapted back to the existing ApiKey/AccessToken view types.
+
+    /// Resolve the current user's id via /api/v1/auth/me. Required because token
+    /// listing is scoped to a user id in 1.2.1.
+    private func currentUserId() async throws -> String {
+        let me: ProfileResponse = try await request("/api/v1/auth/me")
+        return me.id
+    }
 
     func listApiKeys() async throws -> [ApiKey] {
-        let response: ApiKeysListResponse = try await request("/api/v1/profile/api-keys")
-        return response.apiKeys
+        let userId = try await currentUserId()
+        let response: ApiTokenListResponse = try await request("/api/v1/users/\(userId)/tokens")
+        return response.items.map { token in
+            ApiKey(
+                id: token.id,
+                name: token.name,
+                keyPrefix: token.tokenPrefix,
+                createdAt: token.createdAt,
+                expiresAt: token.expiresAt,
+                lastUsedAt: token.lastUsedAt,
+                scopes: token.scopes
+            )
+        }
     }
 
     func createApiKey(name: String, scopes: [String], expiresInDays: Int?) async throws -> CreateApiKeyResponse {
-        try await request(
-            "/api/v1/profile/api-keys",
+        let created: ApiTokenCreatedResponse = try await request(
+            "/api/v1/auth/tokens",
             method: "POST",
             body: CreateApiKeyRequest(name: name, expiresInDays: expiresInDays, scopes: scopes)
         )
+        let apiKey = ApiKey(
+            id: created.id,
+            name: created.name,
+            keyPrefix: String(created.token.prefix(8)),
+            createdAt: "",
+            expiresAt: nil,
+            lastUsedAt: nil,
+            scopes: scopes
+        )
+        return CreateApiKeyResponse(apiKey: apiKey, key: created.token)
     }
 
     func deleteApiKey(_ id: String) async throws {
-        try await requestVoid("/api/v1/profile/api-keys/\(id)", method: "DELETE")
+        try await requestVoid("/api/v1/auth/tokens/\(id)", method: "DELETE")
     }
 
-    // MARK: Access Tokens (profile endpoints not in SDK, kept as raw requests)
-
     func listAccessTokens() async throws -> [AccessToken] {
-        let response: AccessTokensListResponse = try await request("/api/v1/profile/access-tokens")
-        return response.accessTokens
+        let userId = try await currentUserId()
+        let response: ApiTokenListResponse = try await request("/api/v1/users/\(userId)/tokens")
+        return response.items.map { token in
+            AccessToken(
+                id: token.id,
+                name: token.name,
+                tokenPrefix: token.tokenPrefix,
+                createdAt: token.createdAt,
+                expiresAt: token.expiresAt,
+                lastUsedAt: token.lastUsedAt,
+                scopes: token.scopes
+            )
+        }
     }
 
     func createAccessToken(name: String, scopes: [String], expiresInDays: Int?) async throws -> CreateAccessTokenResponse {
-        try await request(
-            "/api/v1/profile/access-tokens",
+        let created: ApiTokenCreatedResponse = try await request(
+            "/api/v1/auth/tokens",
             method: "POST",
             body: CreateAccessTokenRequest(name: name, expiresInDays: expiresInDays, scopes: scopes)
         )
+        let accessToken = AccessToken(
+            id: created.id,
+            name: created.name,
+            tokenPrefix: String(created.token.prefix(8)),
+            createdAt: "",
+            expiresAt: nil,
+            lastUsedAt: nil,
+            scopes: scopes
+        )
+        return CreateAccessTokenResponse(accessToken: accessToken, token: created.token)
     }
 
     func deleteAccessToken(_ id: String) async throws {
-        try await requestVoid("/api/v1/profile/access-tokens/\(id)", method: "DELETE")
+        try await requestVoid("/api/v1/auth/tokens/\(id)", method: "DELETE")
     }
 
     // MARK: Staging Repositories (staging endpoints not in SDK, kept as raw requests)
+
+    // TODO(#42): The whole staging/promotion cluster is deferred to the Staging section
+    // wave. 1.2.1 changed it in two ways that a regression path swap cannot cover:
+    //   1. The /api/v1/staging endpoints were removed. There is no replacement
+    //      "list staging repositories" or "list staging artifacts" operation, so
+    //      listStagingRepos/listStagingArtifacts need a screen redesign over
+    //      list_repositories (filtered by type) and list_artifacts.
+    //   2. Promotion moved to /api/v1/promotion/repositories/... AND the request and
+    //      response bodies changed shape (PromoteArtifactRequest/PromotionResponse/
+    //      BulkPromoteRequest/PromotionHistoryResponse), so promote/bulk/history need
+    //      real model migration, not just a new path.
+    // These call sites are intentionally left on the removed /api/v1/staging paths until
+    // that migration lands in #42; a path-only swap would send the wrong bodies.
 
     func listStagingRepos() async throws -> [StagingRepository] {
         let response: StagingRepositoryListResponse = try await request("/api/v1/staging/repositories")
@@ -373,6 +439,7 @@ actor APIClient {
     }
 
     func promoteArtifact(repoKey: String, artifactId: String, request: PromotionRequest) async throws -> PromotionResponse {
+        // TODO(#42): move to /api/v1/promotion/.../promote with PromoteArtifactRequest body.
         try await self.request(
             "/api/v1/staging/repositories/\(repoKey)/artifacts/\(artifactId)/promote",
             method: "POST",
@@ -381,6 +448,7 @@ actor APIClient {
     }
 
     func promoteBulk(repoKey: String, request: BulkPromotionRequest) async throws -> BulkPromotionResponse {
+        // TODO(#42): move to /api/v1/promotion/.../promote with BulkPromoteRequest body.
         try await self.request(
             "/api/v1/staging/repositories/\(repoKey)/promote-bulk",
             method: "POST",
@@ -389,6 +457,7 @@ actor APIClient {
     }
 
     func getPromotionHistory(repoKey: String) async throws -> [PromotionHistoryEntry] {
+        // TODO(#42): move to /api/v1/promotion/.../promotion-history with the new response shape.
         let response: PromotionHistoryResponse = try await request(
             "/api/v1/staging/repositories/\(repoKey)/history?per_page=100"
         )

--- a/ArtifactKeeper/Sources/Core/Models/Auth.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Auth.swift
@@ -273,3 +273,39 @@ struct CreateAccessTokenResponse: Codable, Sendable {
         case token
     }
 }
+
+// MARK: - Unified API Tokens (1.2.1)
+
+// The 1.2.1 spec replaced the separate /profile/api-keys and /profile/access-tokens
+// surfaces with a single token API: list at /api/v1/users/{id}/tokens, create at
+// /api/v1/auth/tokens, delete at /api/v1/auth/tokens/{token_id}. These types decode
+// that surface; APIClient maps them back to the ApiKey/AccessToken view types so the
+// existing Profile screens are unchanged.
+
+struct ApiTokenResponse: Codable, Sendable {
+    let id: String
+    let name: String
+    let tokenPrefix: String
+    let scopes: [String]
+    let createdAt: String
+    let expiresAt: String?
+    let lastUsedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, scopes
+        case tokenPrefix = "token_prefix"
+        case createdAt = "created_at"
+        case expiresAt = "expires_at"
+        case lastUsedAt = "last_used_at"
+    }
+}
+
+struct ApiTokenListResponse: Codable, Sendable {
+    let items: [ApiTokenResponse]
+}
+
+struct ApiTokenCreatedResponse: Codable, Sendable {
+    let id: String
+    let name: String
+    let token: String
+}

--- a/ArtifactKeeper/Tests/APIClientNetworkTests.swift
+++ b/ArtifactKeeper/Tests/APIClientNetworkTests.swift
@@ -875,16 +875,27 @@ struct APIClientNetworkTests {
         #expect(profile.displayName == "New Name")
     }
 
+    // Token tests target the unified 1.2.1 surface: list via /api/v1/users/{id}/tokens
+    // (preceded by a /api/v1/auth/me call to resolve the user id), create via
+    // /api/v1/auth/tokens, delete via /api/v1/auth/tokens/{id}.
+
     @Test func listApiKeysCallsRequest() async throws {
         let client = makeTestClient()
 
         MockURLProtocol.requestHandler = { request in
-            #expect(request.url?.path == "/api/v1/profile/api-keys")
+            let path = request.url?.path
+            if path == "/api/v1/auth/me" {
+                let me = """
+                {"id": "u1", "username": "testuser", "email": "a@b.c", "is_admin": false, "totp_enabled": false}
+                """
+                return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(me.utf8))
+            }
+            #expect(path == "/api/v1/users/u1/tokens")
             let json = """
             {
-                "api_keys": [
+                "items": [
                     {
-                        "id": "k1", "name": "CI Key", "key_prefix": "ak_",
+                        "id": "k1", "name": "CI Key", "token_prefix": "ak_",
                         "created_at": "2024-01-01T00:00:00Z", "expires_at": null,
                         "last_used_at": null, "scopes": ["read"]
                     }
@@ -910,15 +921,9 @@ struct APIClientNetworkTests {
 
         MockURLProtocol.requestHandler = { request in
             #expect(request.httpMethod == "POST")
+            #expect(request.url?.path == "/api/v1/auth/tokens")
             let json = """
-            {
-                "api_key": {
-                    "id": "k2", "name": "Deploy", "key_prefix": "ak_",
-                    "created_at": "2024-01-01T00:00:00Z", "expires_at": null,
-                    "last_used_at": null, "scopes": ["write"]
-                },
-                "key": "ak_full_key_value"
-            }
+            {"id": "k2", "name": "Deploy", "token": "ak_full_key_value"}
             """
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -938,7 +943,7 @@ struct APIClientNetworkTests {
 
         MockURLProtocol.requestHandler = { request in
             #expect(request.httpMethod == "DELETE")
-            #expect(request.url?.path == "/api/v1/profile/api-keys/key-123")
+            #expect(request.url?.path == "/api/v1/auth/tokens/key-123")
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 204,
@@ -955,10 +960,17 @@ struct APIClientNetworkTests {
         let client = makeTestClient()
 
         MockURLProtocol.requestHandler = { request in
-            #expect(request.url?.path == "/api/v1/profile/access-tokens")
+            let path = request.url?.path
+            if path == "/api/v1/auth/me" {
+                let me = """
+                {"id": "u2", "username": "testuser", "email": "a@b.c", "is_admin": false, "totp_enabled": false}
+                """
+                return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(me.utf8))
+            }
+            #expect(path == "/api/v1/users/u2/tokens")
             let json = """
             {
-                "access_tokens": [
+                "items": [
                     {
                         "id": "t1", "name": "Read Token", "token_prefix": "at_",
                         "created_at": "2024-01-01T00:00:00Z", "expires_at": null,
@@ -986,15 +998,9 @@ struct APIClientNetworkTests {
 
         MockURLProtocol.requestHandler = { request in
             #expect(request.httpMethod == "POST")
+            #expect(request.url?.path == "/api/v1/auth/tokens")
             let json = """
-            {
-                "access_token": {
-                    "id": "t2", "name": "CI Token", "token_prefix": "at_",
-                    "created_at": "2024-01-01T00:00:00Z", "expires_at": null,
-                    "last_used_at": null, "scopes": ["read", "write"]
-                },
-                "token": "at_full_token_value"
-            }
+            {"id": "t2", "name": "CI Token", "token": "at_full_token_value"}
             """
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -1014,7 +1020,7 @@ struct APIClientNetworkTests {
 
         MockURLProtocol.requestHandler = { request in
             #expect(request.httpMethod == "DELETE")
-            #expect(request.url?.path == "/api/v1/profile/access-tokens/token-456")
+            #expect(request.url?.path == "/api/v1/auth/tokens/token-456")
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 204,

--- a/ArtifactKeeper/Tests/APIPathRegressionTests.swift
+++ b/ArtifactKeeper/Tests/APIPathRegressionTests.swift
@@ -1,0 +1,155 @@
+import Testing
+import Foundation
+@testable import ArtifactKeeper
+
+// Verifies the 1.2.1 profile-token path regression is routed to the current spec surface.
+// The v1.2.1 spec removed /api/v1/profile/api-keys and /profile/access-tokens. Tokens now
+// live at /api/v1/auth/tokens (create, delete by id) and /api/v1/users/{id}/tokens (list).
+//
+// Each test captures the outgoing request path via MockURLProtocol and asserts it targets
+// the 1.2.1 surface and never the removed /profile/ paths. MockURLProtocol and makeTestClient
+// are defined in APIClientNetworkTests.swift (same test target).
+
+// A sendable box for recording the paths a sequence of requests hit.
+final class PathRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _paths: [String] = []
+    func record(_ path: String) {
+        lock.lock(); defer { lock.unlock() }
+        _paths.append(path)
+    }
+    var paths: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return _paths
+    }
+}
+
+private func okResponse(_ url: URL, _ body: String, status: Int = 200) -> (HTTPURLResponse, Data) {
+    let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+    return (response, Data(body.utf8))
+}
+
+/// Build an APIClient backed by MockURLProtocol. Defined locally because the
+/// equivalent helper in APIClientNetworkTests.swift is file-private.
+private func makeTokenTestClient(baseURL: String = "https://test-api.example.com") -> APIClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    config.timeoutIntervalForRequest = 5
+    let session = URLSession(configuration: config)
+    return APIClient(baseURL: baseURL, session: session)
+}
+
+@Suite("API Token Path Regression Tests", .serialized)
+struct APITokenPathRegressionTests {
+
+    init() {
+        MockURLProtocol.reset()
+    }
+
+    @Test func listApiKeysTargetsUserTokensPath() async throws {
+        let client = makeTokenTestClient()
+        let recorder = PathRecorder()
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url!.path
+            recorder.record(path)
+            if path == "/api/v1/auth/me" {
+                return okResponse(request.url!, """
+                {"id": "user-7", "username": "alice", "email": "a@b.c", "is_admin": false, "totp_enabled": false}
+                """)
+            }
+            return okResponse(request.url!, "{\"items\": []}")
+        }
+
+        _ = try await client.listApiKeys()
+
+        #expect(recorder.paths.contains("/api/v1/users/user-7/tokens"))
+        #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
+    }
+
+    @Test func createApiKeyTargetsAuthTokensPath() async throws {
+        let client = makeTokenTestClient()
+        let recorder = PathRecorder()
+        MockURLProtocol.requestHandler = { request in
+            recorder.record(request.url!.path)
+            return okResponse(request.url!, """
+            {"id": "tok-1", "name": "ci", "token": "ak_secretvalue"}
+            """, status: 201)
+        }
+
+        let result = try await client.createApiKey(name: "ci", scopes: ["read"], expiresInDays: 90)
+
+        #expect(recorder.paths.contains("/api/v1/auth/tokens"))
+        #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
+        #expect(result.key == "ak_secretvalue")
+    }
+
+    @Test func deleteApiKeyTargetsAuthTokensPath() async throws {
+        let client = makeTokenTestClient()
+        let recorder = PathRecorder()
+        MockURLProtocol.requestHandler = { request in
+            recorder.record(request.url!.path)
+            return okResponse(request.url!, "")
+        }
+
+        try await client.deleteApiKey("tok-9")
+
+        #expect(recorder.paths.contains("/api/v1/auth/tokens/tok-9"))
+        #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
+    }
+
+    @Test func listAccessTokensTargetsUserTokensPath() async throws {
+        let client = makeTokenTestClient()
+        let recorder = PathRecorder()
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url!.path
+            recorder.record(path)
+            if path == "/api/v1/auth/me" {
+                return okResponse(request.url!, """
+                {"id": "user-9", "username": "bob", "email": "b@b.c", "is_admin": true, "totp_enabled": false}
+                """)
+            }
+            return okResponse(request.url!, "{\"items\": []}")
+        }
+
+        _ = try await client.listAccessTokens()
+
+        #expect(recorder.paths.contains("/api/v1/users/user-9/tokens"))
+        #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
+    }
+
+    @Test func createAccessTokenTargetsAuthTokensPath() async throws {
+        let client = makeTokenTestClient()
+        let recorder = PathRecorder()
+        MockURLProtocol.requestHandler = { request in
+            recorder.record(request.url!.path)
+            return okResponse(request.url!, """
+            {"id": "tok-2", "name": "deploy", "token": "ak_secretvalue2"}
+            """, status: 201)
+        }
+
+        let result = try await client.createAccessToken(name: "deploy", scopes: ["write"], expiresInDays: nil)
+
+        #expect(recorder.paths.contains("/api/v1/auth/tokens"))
+        #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
+        #expect(result.token == "ak_secretvalue2")
+    }
+
+    @Test func deleteAccessTokenTargetsAuthTokensPath() async throws {
+        let client = makeTokenTestClient()
+        let recorder = PathRecorder()
+        MockURLProtocol.requestHandler = { request in
+            recorder.record(request.url!.path)
+            return okResponse(request.url!, "")
+        }
+
+        try await client.deleteAccessToken("tok-5")
+
+        #expect(recorder.paths.contains("/api/v1/auth/tokens/tok-5"))
+        #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
+    }
+}
+
+// Promotion/staging path tests are intentionally omitted here: that migration (new
+// /api/v1/promotion paths plus the changed request/response bodies) is deferred to the
+// Staging section wave (#42), so the promote/bulk/history call sites still target their
+// original /api/v1/staging paths in this regression PR.

--- a/project.yml
+++ b/project.yml
@@ -78,5 +78,22 @@ targets:
     settings:
       base:
         SWIFT_VERSION: "6.0"
+        GENERATE_INFOPLIST_FILE: YES
     dependencies:
       - target: ArtifactKeeper_${platform}
+
+schemes:
+  ArtifactKeeper_macOS:
+    build:
+      targets:
+        ArtifactKeeper_macOS: all
+    test:
+      targets:
+        - ArtifactKeeperTests_macOS
+  ArtifactKeeper_iOS:
+    build:
+      targets:
+        ArtifactKeeper_iOS: all
+    test:
+      targets:
+        - ArtifactKeeperTests_iOS


### PR DESCRIPTION
## Summary
Profile token management called paths removed in API v1.2.1 (compiled, 404 at runtime). Routes both Profile tabs (API keys + access tokens) onto the unified 1.2.1 token surface:
- list: GET /api/v1/users/{id}/tokens (id resolved via /api/v1/auth/me)
- create: POST /api/v1/auth/tokens
- delete: DELETE /api/v1/auth/tokens/{token_id}

Adds unified models (ApiTokenResponse/ApiTokenListResponse/ApiTokenCreatedResponse) adapted back to the existing ApiKey/AccessToken view types; views untouched. Also wires a test action into the schemes so `xcodebuild test` runs (the scheme previously had no test action, so tests never executed in CI).

Promotion/staging migration is out of scope (1.2.1 changed request/response body shapes, not just paths); tracked for the Staging section wave in #42.

Rebased onto main after the foundation PR (#44) merged.

Closes #41

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## Platform
- [x] Tested on macOS
- [ ] Tested on iOS simulator
- [ ] SwiftUI previews render correctly
- [x] N/A - no UI changes (routing + models only)