### PR TITLE
feat(ios): artifact detail screen with metadata, stats, and labels

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0050E6CD740666B06CF4F1F6 /* DependencyTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */; };
 		03D59745AFA47FE8D1811B9A /* SecurityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7351368D8EDB157E264ECBBC /* SecurityView.swift */; };
+		045038A865E03603D632D162 /* ArtifactDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE37B413A2C453F93480A64 /* ArtifactDetailViewModel.swift */; };
+		04B038DD0B0B8611B2FB91F2 /* ArtifactDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE2C5256F844F6279846227 /* ArtifactDetail.swift */; };
 		04D04D992D40CBE4A2A9A8D5 /* MonitoringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F6787AE2A18008C8EA282F /* MonitoringView.swift */; };
 		04E9EC2157EA947C8B9FE159 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C4236474392052DD29004F /* DashboardView.swift */; };
 		083E2EBD72FFCF6E3EDEA31B /* DtDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59106973EB99FD9424D44224 /* DtDashboardView.swift */; };
@@ -51,6 +53,7 @@
 		3E86A76D6A7C20EB5128C9B9 /* SDKClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */; };
 		42DD12D515613DB543BCD922 /* TelemetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4252913A5015A9448F73683 /* TelemetryView.swift */; };
 		431F59BD5A02CA08C396903A /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73AE1952EFB3C338C7D0771 /* LoginView.swift */; };
+		435F616F353CDF139BE4859E /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F289613B7B5E1B85C3F9E832 /* ArtifactDetailView.swift */; };
 		43CD93CC42B93AE1999FA8B9 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84212AD84A94810D2C23339 /* AuthManagerTests.swift */; };
 		475F7C0CA9365AB11D952814 /* ReplicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8067728F7917AD61F0DB4037 /* ReplicationView.swift */; };
 		47DFA7F8B01E5A21906642A2 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DDB4F8B15C1FB99A2843 /* Package.swift */; };
@@ -59,6 +62,7 @@
 		4EAE9C1A06FF203ED9F5CC77 /* TOTPVerificationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */; };
 		4F9A68618BD7C56914CA8D65 /* OpenAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 068276BAE547E09F546FF9A8 /* OpenAPIRuntime */; };
 		50E508B7E51DFFC65B9BCBCE /* PoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */; };
+		5320A1E01878293E6B13C800 /* ArtifactDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A41A1778E2034F039852708 /* ArtifactDetailTests.swift */; };
 		540BD81E8B758B26D1D5A040 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341E812182C7DEF2DE15BDE6 /* AuthManager.swift */; };
 		55D6428BD2147FDF7F9BA85A /* StagingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970FC2E2E5418295A48A9B0E /* StagingListView.swift */; };
 		55E48C58A4F43DC5DC868FE0 /* Promotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CA7F1FBDE367A6D4052F47 /* Promotion.swift */; };
@@ -78,11 +82,13 @@
 		63E7289229BE580CA9FC610C /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F86EB93D00E4631A8F8F9C /* Artifact.swift */; };
 		64C2073204C6C5D5B1248E52 /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CFB90021A1428D8962F1BF /* Operations.swift */; };
 		653D84744E6345714FCE559A /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84212AD84A94810D2C23339 /* AuthManagerTests.swift */; };
+		661675A6E9DC360473BAA181 /* ArtifactDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE2C5256F844F6279846227 /* ArtifactDetail.swift */; };
 		66342C499ECF4ADDCCF83FFC /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341E812182C7DEF2DE15BDE6 /* AuthManager.swift */; };
 		67018A342717D2F56ADA6F58 /* TOTPVerificationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */; };
 		6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */; };
 		706149420AF74CC3C2F55FDB /* PoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */; };
 		71DE9560CF0DC604499711B9 /* ServerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */; };
+		71FC30A34A235CFE53B1D1DF /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F289613B7B5E1B85C3F9E832 /* ArtifactDetailView.swift */; };
 		738EFB98489D855A1E2FFE8B /* SetupInstructionsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F4BB814BCEC4170B1CA727 /* SetupInstructionsViewTests.swift */; };
 		76A035773BD7C7A5065F5E65 /* ServerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */; };
 		7795B1C86E7E5530C0ECA6BE /* SbomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACFAEE53DF20945E710A82E /* SbomView.swift */; };
@@ -148,6 +154,7 @@
 		CB9F64C28FEBB032DD2210F6 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FB2391848A9D7A02E4F7DC /* Repository.swift */; };
 		CBA92159E5A5DFC00F6CBC28 /* RepositoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9688E0041F1683C5DDFA6071 /* RepositoriesView.swift */; };
 		CE29910E19439190B021FD6B /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F86EB93D00E4631A8F8F9C /* Artifact.swift */; };
+		D0480DCE5F0F50B390F15993 /* ArtifactDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE37B413A2C453F93480A64 /* ArtifactDetailViewModel.swift */; };
 		D11B924C3B8CFCE3F0E46905 /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */; };
 		D3653822D6C8332BC92D8642 /* SSOView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C66794630C443427F1527 /* SSOView.swift */; };
 		D36FF1BE98A8940CC8E38C27 /* DependencyTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */; };
@@ -175,6 +182,7 @@
 		F790A545605AFA178BEEA506 /* WebhooksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8063DEF3B0228C26496797B7 /* WebhooksView.swift */; };
 		FABB8132DF5CEA339A9B769A /* APIPathRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */; };
 		FB1F242DC31148C08DA16397 /* APIClientNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */; };
+		FBB9BAC6869454925F45B080 /* ArtifactDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A41A1778E2034F039852708 /* ArtifactDetailTests.swift */; };
 		FCA0BB626B22F06543044B90 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9050B925E8CDAB492ED01C01 /* AnalyticsView.swift */; };
 		FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942CFADFFB28FA592F32CAB1 /* ModelTests.swift */; };
 		FDD83FAF91847C130D24C7ED /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79512BEEB0DBDA10DFDCFAAC /* MainTabView.swift */; };
@@ -224,6 +232,9 @@
 		5B6A94422BAD7B966077C0D9 /* OperationsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationsSectionView.swift; sourceTree = "<group>"; };
 		5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensePoliciesView.swift; sourceTree = "<group>"; };
 		65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerManagerTests.swift; sourceTree = "<group>"; };
+		6A41A1778E2034F039852708 /* ArtifactDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailTests.swift; sourceTree = "<group>"; };
+		6FE2C5256F844F6279846227 /* ArtifactDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetail.swift; sourceTree = "<group>"; };
+		6FE37B413A2C453F93480A64 /* ArtifactDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailViewModel.swift; sourceTree = "<group>"; };
 		71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientExtendedTests.swift; sourceTree = "<group>"; };
 		72273F4294E6BC2DA2D09609 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		7351368D8EDB157E264ECBBC /* SecurityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityView.swift; sourceTree = "<group>"; };
@@ -277,6 +288,7 @@
 		EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPathRegressionTests.swift; sourceTree = "<group>"; };
 		F0896BDB350847081B1C7EA3 /* EditRepositorySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRepositorySheet.swift; sourceTree = "<group>"; };
 		F130C4E4EC403EC23594AE44 /* PeersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeersView.swift; sourceTree = "<group>"; };
+		F289613B7B5E1B85C3F9E832 /* ArtifactDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailView.swift; sourceTree = "<group>"; };
 		F73AE1952EFB3C338C7D0771 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		F84212AD84A94810D2C23339 /* AuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
 		F8761FACD0287EF99C0A1E50 /* UsersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersView.swift; sourceTree = "<group>"; };
@@ -352,6 +364,7 @@
 				785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */,
 				1901D688CCAD3DE71AA681AC /* APIClientTests.swift */,
 				EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */,
+				6A41A1778E2034F039852708 /* ArtifactDetailTests.swift */,
 				C8A1761272FDDB00A7D41243 /* ArtifactKeeperTests.swift */,
 				E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */,
 				F84212AD84A94810D2C23339 /* AuthManagerTests.swift */,
@@ -405,6 +418,7 @@
 			children = (
 				9CBE59905B179E64919791A7 /* Admin.swift */,
 				59F86EB93D00E4631A8F8F9C /* Artifact.swift */,
+				6FE2C5256F844F6279846227 /* ArtifactDetail.swift */,
 				E59705D3B5F2000ACABB8A48 /* Auth.swift */,
 				90190CE35DA804C357A5FFDB /* Build.swift */,
 				C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */,
@@ -439,6 +453,15 @@
 				BD2E5BB60BE578603D5B6925 /* BuildsView.swift */,
 			);
 			path = Builds;
+			sourceTree = "<group>";
+		};
+		67DF4E3C92C2D392305EE48A /* Artifacts */ = {
+			isa = PBXGroup;
+			children = (
+				F289613B7B5E1B85C3F9E832 /* ArtifactDetailView.swift */,
+				6FE37B413A2C453F93480A64 /* ArtifactDetailViewModel.swift */,
+			);
+			path = Artifacts;
 			sourceTree = "<group>";
 		};
 		7CF61EF0422A0C89FC96ECB8 /* Dashboard */ = {
@@ -541,6 +564,7 @@
 			isa = PBXGroup;
 			children = (
 				EC1642742F423D764BC9FA0A /* Admin */,
+				67DF4E3C92C2D392305EE48A /* Artifacts */,
 				5C517A72E7A87F9765B505DE /* Builds */,
 				7CF61EF0422A0C89FC96ECB8 /* Dashboard */,
 				F17866B4DADD535323D2A2E4 /* Integration */,
@@ -765,6 +789,7 @@
 				FB1F242DC31148C08DA16397 /* APIClientNetworkTests.swift in Sources */,
 				AD2DBF5F7973BE47E351CC36 /* APIClientTests.swift in Sources */,
 				D6F8DEBE6DBFB0A7A1F1EB1F /* APIPathRegressionTests.swift in Sources */,
+				5320A1E01878293E6B13C800 /* ArtifactDetailTests.swift in Sources */,
 				571951B0A6024875CE31B544 /* ArtifactKeeperTests.swift in Sources */,
 				A1A538DE905D6AF031923CF5 /* AuthManagerExtendedTests.swift in Sources */,
 				43CD93CC42B93AE1999FA8B9 /* AuthManagerTests.swift in Sources */,
@@ -787,6 +812,9 @@
 				22E710F949296F2C4F470275 /* AdminSectionView.swift in Sources */,
 				C003F153FD58DC40599D6AA3 /* AnalyticsView.swift in Sources */,
 				CE29910E19439190B021FD6B /* Artifact.swift in Sources */,
+				661675A6E9DC360473BAA181 /* ArtifactDetail.swift in Sources */,
+				71FC30A34A235CFE53B1D1DF /* ArtifactDetailView.swift in Sources */,
+				045038A865E03603D632D162 /* ArtifactDetailViewModel.swift in Sources */,
 				D6794B241227A7A33DE011F3 /* ArtifactKeeperApp.swift in Sources */,
 				B4D6FB0A72BFCD4B4251E2E2 /* ArtifactsSectionView.swift in Sources */,
 				B6A85BC097A24998642C5C9A /* Auth.swift in Sources */,
@@ -858,6 +886,7 @@
 				189014CE0807785BF1C97AF6 /* APIClientNetworkTests.swift in Sources */,
 				7B983BDEC8F0E8548B9E7E5E /* APIClientTests.swift in Sources */,
 				FABB8132DF5CEA339A9B769A /* APIPathRegressionTests.swift in Sources */,
+				FBB9BAC6869454925F45B080 /* ArtifactDetailTests.swift in Sources */,
 				17488E98D524FCAB892BAAC5 /* ArtifactKeeperTests.swift in Sources */,
 				F5CE55686817D88933AC4AC1 /* AuthManagerExtendedTests.swift in Sources */,
 				653D84744E6345714FCE559A /* AuthManagerTests.swift in Sources */,
@@ -880,6 +909,9 @@
 				5F75063CEDB21ADEE50D095C /* AdminSectionView.swift in Sources */,
 				FCA0BB626B22F06543044B90 /* AnalyticsView.swift in Sources */,
 				63E7289229BE580CA9FC610C /* Artifact.swift in Sources */,
+				04B038DD0B0B8611B2FB91F2 /* ArtifactDetail.swift in Sources */,
+				435F616F353CDF139BE4859E /* ArtifactDetailView.swift in Sources */,
+				D0480DCE5F0F50B390F15993 /* ArtifactDetailViewModel.swift in Sources */,
 				5F2BF946886E0871236036AC /* ArtifactKeeperApp.swift in Sources */,
 				38E52404189326A2143B485E /* ArtifactsSectionView.swift in Sources */,
 				ABC754B5DC49717B25A912DB /* Auth.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -464,6 +464,48 @@ actor APIClient {
         return response.items
     }
 
+    // MARK: Artifact Detail (1.2.1: /api/v1/artifacts/{id} + /metadata, /stats, /labels)
+
+    func getArtifactDetail(id: String) async throws -> ArtifactDetail {
+        try await request("/api/v1/artifacts/\(id)")
+    }
+
+    func getArtifactMetadata(id: String) async throws -> ArtifactMetadata {
+        try await request("/api/v1/artifacts/\(id)/metadata")
+    }
+
+    func getArtifactStats(id: String) async throws -> ArtifactStats {
+        try await request("/api/v1/artifacts/\(id)/stats")
+    }
+
+    func listArtifactLabels(id: String) async throws -> [ArtifactLabel] {
+        let response: ArtifactLabelsListResponse = try await request("/api/v1/artifacts/\(id)/labels")
+        return response.items
+    }
+
+    /// Replace the full label set on an artifact.
+    func setArtifactLabels(id: String, labels: [ArtifactLabelEntry]) async throws -> [ArtifactLabel] {
+        let response: ArtifactLabelsListResponse = try await request(
+            "/api/v1/artifacts/\(id)/labels",
+            method: "PUT",
+            body: SetArtifactLabelsRequest(labels: labels)
+        )
+        return response.items
+    }
+
+    /// Add or update a single label by key.
+    func addArtifactLabel(id: String, key: String, value: String?) async throws -> ArtifactLabel {
+        try await request(
+            "/api/v1/artifacts/\(id)/labels/\(key)",
+            method: "POST",
+            body: AddArtifactLabelRequest(value: value)
+        )
+    }
+
+    func deleteArtifactLabel(id: String, key: String) async throws {
+        try await requestVoid("/api/v1/artifacts/\(id)/labels/\(key)", method: "DELETE")
+    }
+
     // MARK: Virtual Repository Members
 
     func listVirtualMembers(repoKey: String) async throws -> [VirtualMember] {

--- a/ArtifactKeeper/Sources/Core/Models/ArtifactDetail.swift
+++ b/ArtifactKeeper/Sources/Core/Models/ArtifactDetail.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+// Models for the 1.2.1 Artifact Detail surface: GET /api/v1/artifacts/{id},
+// /metadata, /stats, and the artifact-labels CRUD endpoints. These decode the
+// REST responses directly (matching the existing raw-request pattern used across
+// Features) so they are exercisable in tests via the mock URL protocol.
+
+struct ArtifactDetail: Codable, Sendable, Identifiable {
+    let id: String
+    let repositoryKey: String
+    let path: String
+    let name: String
+    let version: String?
+    let contentType: String
+    let sizeBytes: Int64
+    let checksumSha256: String
+    let downloadCount: Int
+    let createdAt: String
+    let cacheCachedAt: String?
+    let cacheExpiresAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, path, version
+        case repositoryKey = "repository_key"
+        case contentType = "content_type"
+        case sizeBytes = "size_bytes"
+        case checksumSha256 = "checksum_sha256"
+        case downloadCount = "download_count"
+        case createdAt = "created_at"
+        case cacheCachedAt = "cache_cached_at"
+        case cacheExpiresAt = "cache_expires_at"
+    }
+}
+
+struct ArtifactMetadata: Codable, Sendable {
+    let artifactId: String
+    let format: String
+    // metadata and properties are free-form JSON objects in the spec. They are
+    // surfaced to the UI as decoded key/value strings for display.
+    let metadata: [String: JSONValue]?
+    let properties: [String: JSONValue]?
+
+    enum CodingKeys: String, CodingKey {
+        case artifactId = "artifact_id"
+        case format, metadata, properties
+    }
+}
+
+struct ArtifactStats: Codable, Sendable {
+    let artifactId: String
+    let downloadCount: Int
+    let firstDownloaded: String?
+    let lastDownloaded: String?
+
+    enum CodingKeys: String, CodingKey {
+        case artifactId = "artifact_id"
+        case downloadCount = "download_count"
+        case firstDownloaded = "first_downloaded"
+        case lastDownloaded = "last_downloaded"
+    }
+}
+
+// MARK: - Labels
+
+struct ArtifactLabel: Codable, Sendable, Identifiable, Hashable {
+    let id: String
+    let artifactId: String
+    let key: String
+    let value: String
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, key, value
+        case artifactId = "artifact_id"
+        case createdAt = "created_at"
+    }
+}
+
+struct ArtifactLabelsListResponse: Codable, Sendable {
+    let items: [ArtifactLabel]
+    let total: Int
+}
+
+struct ArtifactLabelEntry: Codable, Sendable {
+    let key: String
+    let value: String?
+}
+
+struct SetArtifactLabelsRequest: Codable, Sendable {
+    let labels: [ArtifactLabelEntry]
+}
+
+struct AddArtifactLabelRequest: Codable, Sendable {
+    let value: String?
+}
+
+// A minimal JSON value used to decode the free-form metadata/properties objects
+// without losing data, so the detail screen can render arbitrary key/value pairs.
+enum JSONValue: Codable, Sendable, Hashable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let b = try? container.decode(Bool.self) {
+            self = .bool(b)
+        } else if let n = try? container.decode(Double.self) {
+            self = .number(n)
+        } else if let s = try? container.decode(String.self) {
+            self = .string(s)
+        } else if let a = try? container.decode([JSONValue].self) {
+            self = .array(a)
+        } else if let o = try? container.decode([String: JSONValue].self) {
+            self = .object(o)
+        } else {
+            self = .null
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let s): try container.encode(s)
+        case .number(let n): try container.encode(n)
+        case .bool(let b): try container.encode(b)
+        case .null: try container.encodeNil()
+        case .array(let a): try container.encode(a)
+        case .object(let o): try container.encode(o)
+        }
+    }
+
+    /// A short display string for rendering scalar values in a list row.
+    var displayString: String {
+        switch self {
+        case .string(let s): return s
+        case .number(let n): return n == n.rounded() ? String(Int(n)) : String(n)
+        case .bool(let b): return b ? "true" : "false"
+        case .null: return "null"
+        case .array(let a): return "[\(a.count) items]"
+        case .object(let o): return "{\(o.count) fields}"
+        }
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Artifacts/ArtifactDetailView.swift
+++ b/ArtifactKeeper/Sources/Features/Artifacts/ArtifactDetailView.swift
@@ -76,11 +76,34 @@ struct ArtifactDetailView: View {
                 if let stats = viewModel.stats { statsSection(stats) }
                 if let metadata = viewModel.metadata { metadataSection(metadata) }
                 labelsSection
+                downloadSection(detail)
             }
             .refreshable { await viewModel.load() }
         } else {
             ContentUnavailableView("No Artifact", systemImage: "shippingbox")
         }
+    }
+
+    // Simple download affordance: opens the artifact's download URL in the system
+    // browser. No streaming/download-manager infra; the heavier upload/chunked
+    // flows are deferred to a later wave.
+    private func downloadSection(_ detail: ArtifactDetail) -> some View {
+        Section {
+            Button {
+                Task { await openDownload(detail) }
+            } label: {
+                Label("Download in Browser", systemImage: "arrow.down.circle")
+            }
+        }
+    }
+
+    private func openDownload(_ detail: ArtifactDetail) async {
+        guard let url = await viewModel.downloadURL(repoKey: repoKey, path: detail.path) else { return }
+        #if os(iOS)
+        await UIApplication.shared.open(url)
+        #elseif os(macOS)
+        await MainActor.run { _ = NSWorkspace.shared.open(url) }
+        #endif
     }
 
     private func infoSection(_ detail: ArtifactDetail) -> some View {

--- a/ArtifactKeeper/Sources/Features/Artifacts/ArtifactDetailView.swift
+++ b/ArtifactKeeper/Sources/Features/Artifacts/ArtifactDetailView.swift
@@ -1,0 +1,248 @@
+import SwiftUI
+
+// The Artifact Detail screen for the 1.2.1 artifact endpoints. Fetches full
+// detail, format metadata, download stats and labels, and lets the user add or
+// remove labels. Presented as a sheet from the repository artifact list.
+struct ArtifactDetailView: View {
+    let repoKey: String
+
+    @StateObject private var viewModel: ArtifactDetailView.Model
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showAddLabel = false
+    @State private var labelToDelete: ArtifactLabel?
+
+    typealias Model = ArtifactDetailViewModel
+
+    init(artifactId: String, repoKey: String, api: APIClient = .shared) {
+        self.repoKey = repoKey
+        _viewModel = StateObject(wrappedValue: ArtifactDetailViewModel(artifactId: artifactId, api: api))
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Artifact")
+                #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+                #endif
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+                .task { await viewModel.load() }
+                .sheet(isPresented: $showAddLabel) {
+                    AddLabelSheet { key, value in
+                        await viewModel.addLabel(key: key, value: value)
+                    }
+                }
+                .alert(
+                    "Remove Label?",
+                    isPresented: Binding(
+                        get: { labelToDelete != nil },
+                        set: { if !$0 { labelToDelete = nil } }
+                    )
+                ) {
+                    Button("Cancel", role: .cancel) {}
+                    Button("Remove", role: .destructive) {
+                        if let label = labelToDelete {
+                            Task { await viewModel.deleteLabel(key: label.key) }
+                        }
+                    }
+                } message: {
+                    Text("This removes the label from the artifact.")
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.isLoading && viewModel.detail == nil {
+            ProgressView("Loading artifact\u{2026}")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = viewModel.errorMessage, viewModel.detail == nil {
+            ContentUnavailableView {
+                Label("Could Not Load Artifact", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Retry") { Task { await viewModel.load() } }
+            }
+        } else if let detail = viewModel.detail {
+            List {
+                infoSection(detail)
+                checksumSection(detail)
+                if let stats = viewModel.stats { statsSection(stats) }
+                if let metadata = viewModel.metadata { metadataSection(metadata) }
+                labelsSection
+            }
+            .refreshable { await viewModel.load() }
+        } else {
+            ContentUnavailableView("No Artifact", systemImage: "shippingbox")
+        }
+    }
+
+    private func infoSection(_ detail: ArtifactDetail) -> some View {
+        Section("Artifact") {
+            LabeledContent("Name", value: detail.name)
+            LabeledContent("Path", value: detail.path)
+            if let version = detail.version, !version.isEmpty {
+                LabeledContent("Version", value: version)
+            }
+            LabeledContent("Repository", value: detail.repositoryKey)
+            LabeledContent("Content Type", value: detail.contentType)
+            LabeledContent("Size", value: Self.formatBytes(detail.sizeBytes))
+            LabeledContent("Downloads", value: "\(detail.downloadCount)")
+            LabeledContent("Created", value: detail.createdAt)
+        }
+    }
+
+    @ViewBuilder
+    private func checksumSection(_ detail: ArtifactDetail) -> some View {
+        if !detail.checksumSha256.isEmpty {
+            Section("Checksum") {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("SHA-256").font(.caption).foregroundStyle(.secondary)
+                    Text(detail.checksumSha256)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private func statsSection(_ stats: ArtifactStats) -> some View {
+        Section("Download Stats") {
+            LabeledContent("Total Downloads", value: "\(stats.downloadCount)")
+            if let first = stats.firstDownloaded {
+                LabeledContent("First Download", value: first)
+            }
+            if let last = stats.lastDownloaded {
+                LabeledContent("Last Download", value: last)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func metadataSection(_ metadata: ArtifactMetadata) -> some View {
+        Section("Metadata") {
+            LabeledContent("Format", value: metadata.format)
+            ForEach(Self.sortedPairs(metadata.metadata), id: \.0) { pair in
+                LabeledContent(pair.0, value: pair.1)
+            }
+        }
+        let properties = Self.sortedPairs(metadata.properties)
+        if !properties.isEmpty {
+            Section("Properties") {
+                ForEach(properties, id: \.0) { pair in
+                    LabeledContent(pair.0, value: pair.1)
+                }
+            }
+        }
+    }
+
+    private var labelsSection: some View {
+        Section {
+            if viewModel.labels.isEmpty {
+                Text("No labels")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(viewModel.labels) { label in
+                    HStack {
+                        Image(systemName: "tag")
+                            .foregroundStyle(.secondary)
+                        Text(label.key).fontWeight(.medium)
+                        Spacer()
+                        Text(label.value).foregroundStyle(.secondary)
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            labelToDelete = label
+                        } label: {
+                            Label("Remove", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+            if let labelError = viewModel.labelError {
+                Text(labelError).font(.caption).foregroundStyle(.red)
+            }
+        } header: {
+            HStack {
+                Text("Labels")
+                Spacer()
+                Button {
+                    showAddLabel = true
+                } label: {
+                    Image(systemName: "plus.circle")
+                }
+                .disabled(viewModel.isMutatingLabels)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    static func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
+    }
+
+    static func sortedPairs(_ map: [String: JSONValue]?) -> [(String, String)] {
+        guard let map else { return [] }
+        return map.map { ($0.key, $0.value.displayString) }.sorted { $0.0 < $1.0 }
+    }
+}
+
+// MARK: - Add Label Sheet
+
+private struct AddLabelSheet: View {
+    let onAdd: (String, String) async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var key = ""
+    @State private var value = ""
+    @State private var isSaving = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Label") {
+                    TextField("Key", text: $key)
+                        .autocorrectionDisabled()
+                        #if os(iOS)
+                        .textInputAutocapitalization(.never)
+                        #endif
+                    TextField("Value", text: $value)
+                        .autocorrectionDisabled()
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle("Add Label")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task {
+                            isSaving = true
+                            await onAdd(key, value)
+                            isSaving = false
+                            dismiss()
+                        }
+                    } label: {
+                        if isSaving { ProgressView().controlSize(.small) } else { Text("Add") }
+                    }
+                    .disabled(key.trimmingCharacters(in: .whitespaces).isEmpty || isSaving)
+                }
+            }
+        }
+        .frame(minWidth: 320, minHeight: 220)
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Artifacts/ArtifactDetailViewModel.swift
+++ b/ArtifactKeeper/Sources/Features/Artifacts/ArtifactDetailViewModel.swift
@@ -1,0 +1,94 @@
+import Foundation
+import SwiftUI
+
+// Drives the Artifact Detail screen against the 1.2.1 artifact endpoints:
+// detail, metadata, stats, and the artifact-labels CRUD. Loads run concurrently
+// and degrade independently so a failure in one section does not blank the screen.
+@MainActor
+final class ArtifactDetailViewModel: ObservableObject {
+    @Published var detail: ArtifactDetail?
+    @Published var metadata: ArtifactMetadata?
+    @Published var stats: ArtifactStats?
+    @Published var labels: [ArtifactLabel] = []
+
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var labelError: String?
+    @Published var isMutatingLabels = false
+
+    let artifactId: String
+    private let api: APIClient
+
+    init(artifactId: String, api: APIClient = .shared) {
+        self.artifactId = artifactId
+        self.api = api
+    }
+
+    /// Load detail, metadata, stats and labels. The core detail call drives the
+    /// top-level error state; metadata/stats/labels are best-effort so a partial
+    /// backend still renders a useful screen.
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            detail = try await api.getArtifactDetail(id: artifactId)
+        } catch {
+            errorMessage = Self.message(from: error)
+            isLoading = false
+            return
+        }
+
+        async let metadataResult = try? api.getArtifactMetadata(id: artifactId)
+        async let statsResult = try? api.getArtifactStats(id: artifactId)
+        async let labelsResult = try? api.listArtifactLabels(id: artifactId)
+
+        metadata = await metadataResult
+        stats = await statsResult
+        labels = await labelsResult ?? []
+
+        isLoading = false
+    }
+
+    /// Reload only the label set, used after add/delete.
+    func reloadLabels() async {
+        labels = (try? await api.listArtifactLabels(id: artifactId)) ?? labels
+    }
+
+    func addLabel(key: String, value: String) async {
+        let trimmedKey = key.trimmingCharacters(in: .whitespaces)
+        guard !trimmedKey.isEmpty else { return }
+        isMutatingLabels = true
+        labelError = nil
+        defer { isMutatingLabels = false }
+        do {
+            let trimmedValue = value.trimmingCharacters(in: .whitespaces)
+            _ = try await api.addArtifactLabel(
+                id: artifactId,
+                key: trimmedKey,
+                value: trimmedValue.isEmpty ? nil : trimmedValue
+            )
+            await reloadLabels()
+        } catch {
+            labelError = Self.message(from: error)
+        }
+    }
+
+    func deleteLabel(key: String) async {
+        isMutatingLabels = true
+        labelError = nil
+        defer { isMutatingLabels = false }
+        do {
+            try await api.deleteArtifactLabel(id: artifactId, key: key)
+            await reloadLabels()
+        } catch {
+            labelError = Self.message(from: error)
+        }
+    }
+
+    private static func message(from error: Error) -> String {
+        if let apiError = error as? APIError {
+            return apiError.localizedDescription
+        }
+        return error.localizedDescription
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Artifacts/ArtifactDetailViewModel.swift
+++ b/ArtifactKeeper/Sources/Features/Artifacts/ArtifactDetailViewModel.swift
@@ -49,6 +49,12 @@ final class ArtifactDetailViewModel: ObservableObject {
         isLoading = false
     }
 
+    /// Build the browser download URL for this artifact's path. Returns nil when
+    /// no server is configured.
+    func downloadURL(repoKey: String, path: String) async -> URL? {
+        await api.buildDownloadURL(repoKey: repoKey, artifactPath: path)
+    }
+
     /// Reload only the label set, used after add/delete.
     func reloadLabels() async {
         labels = (try? await api.listArtifactLabels(id: artifactId)) ?? labels

--- a/ArtifactKeeper/Sources/Features/Repositories/RepositoriesView.swift
+++ b/ArtifactKeeper/Sources/Features/Repositories/RepositoriesView.swift
@@ -343,7 +343,7 @@ struct RepositoryDetailView: View {
             await loadData()
         }
         .sheet(item: $selectedArtifact) { artifact in
-            ArtifactDetailSheet(artifact: artifact, repoKey: repoKey)
+            ArtifactDetailView(artifactId: artifact.id, repoKey: repoKey)
         }
         .sheet(item: $securityArtifact) { artifact in
             NavigationStack {
@@ -445,86 +445,6 @@ struct ArtifactRow: View {
             }
         }
         .padding(.vertical, 2)
-    }
-}
-
-// MARK: - Artifact Detail Sheet
-
-struct ArtifactDetailSheet: View {
-    let artifact: Artifact
-    let repoKey: String
-    @Environment(\.dismiss) private var dismiss
-
-    private let apiClient = APIClient.shared
-
-    private func formatBytes(_ bytes: Int64) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: bytes)
-    }
-
-    var body: some View {
-        NavigationStack {
-            List {
-                Section("Artifact Info") {
-                    LabeledContent("Name", value: artifact.name)
-                    LabeledContent("Path", value: artifact.path)
-                    if let version = artifact.version {
-                        LabeledContent("Version", value: version)
-                    }
-                    LabeledContent("Content Type", value: artifact.contentType ?? "unknown")
-                    LabeledContent("Size", value: formatBytes(artifact.sizeBytes))
-                    LabeledContent("Downloads", value: "\(artifact.downloadCount)")
-                }
-
-                if let checksum = artifact.checksumSha256, !checksum.isEmpty {
-                    Section("Checksums") {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("SHA-256")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(checksum)
-                                .font(.system(.caption, design: .monospaced))
-                                .textSelection(.enabled)
-                        }
-                    }
-                }
-
-                Section {
-                    Button {
-                        openDownloadURL()
-                    } label: {
-                        HStack {
-                            Image(systemName: "safari")
-                            Text("Download in Browser")
-                        }
-                    }
-                }
-            }
-            .navigationTitle("Artifact Details")
-            #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        dismiss()
-                    }
-                }
-            }
-        }
-    }
-
-    private func openDownloadURL() {
-        Task {
-            if let url = await apiClient.buildDownloadURL(repoKey: repoKey, artifactPath: artifact.path) {
-                #if os(iOS)
-                await UIApplication.shared.open(url)
-                #elseif os(macOS)
-                await MainActor.run { _ = NSWorkspace.shared.open(url) }
-                #endif
-            }
-        }
     }
 }
 

--- a/ArtifactKeeper/Sources/Features/Repositories/RepositoryDetailTabbedView.swift
+++ b/ArtifactKeeper/Sources/Features/Repositories/RepositoryDetailTabbedView.swift
@@ -63,7 +63,7 @@ struct RepositoryDetailTabbedView: View {
             await loadData()
         }
         .sheet(item: $selectedArtifact) { artifact in
-            ArtifactDetailSheet(artifact: artifact, repoKey: repoKey)
+            ArtifactDetailView(artifactId: artifact.id, repoKey: repoKey)
         }
         .sheet(item: $securityArtifact) { artifact in
             NavigationStack {

--- a/ArtifactKeeper/Tests/APIClientNetworkTests.swift
+++ b/ArtifactKeeper/Tests/APIClientNetworkTests.swift
@@ -11,14 +11,47 @@ final class AuthFailureTracker: Sendable {
     func markCalled() { wasCalled = true }
 }
 
+/// Thread-safe counter for use inside @Sendable mock handlers, which cannot
+/// capture a mutable local var.
+final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    @discardableResult
+    func increment() -> Int { lock.lock(); defer { lock.unlock() }; value += 1; return value }
+    var count: Int { lock.lock(); defer { lock.unlock() }; return value }
+}
+
 // MARK: - Mock URL Protocol
 
-/// A URLProtocol subclass that returns stubbed responses for testing.
-/// Configured per-test via static properties.
+typealias MockRequestHandler = @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+
+/// A URLProtocol that returns stubbed responses for testing. Handlers are stored
+/// per session (keyed by an id injected into the session's headers) in a
+/// thread-safe registry, NOT in a single global. Swift Testing runs suites in
+/// parallel, and a shared global handler caused concurrent tests to overwrite and
+/// read each other's stub. Per-session isolation makes every test's APIClient see
+/// only its own handler, so the suites are safe to run in parallel.
 final class MockURLProtocol: URLProtocol, @unchecked Sendable {
 
-    /// Handler called for each request. Return (response, data) or throw.
-    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    static let sessionHeader = "X-Mock-Session-ID"
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var handlers: [String: MockRequestHandler] = [:]
+
+    static func setHandler(for id: String, _ handler: @escaping MockRequestHandler) {
+        lock.lock(); defer { lock.unlock() }
+        handlers[id] = handler
+    }
+
+    static func handler(for id: String) -> MockRequestHandler? {
+        lock.lock(); defer { lock.unlock() }
+        return handlers[id]
+    }
+
+    static func removeHandler(for id: String) {
+        lock.lock(); defer { lock.unlock() }
+        handlers[id] = nil
+    }
 
     override class func canInit(with request: URLRequest) -> Bool {
         return true
@@ -29,9 +62,10 @@ final class MockURLProtocol: URLProtocol, @unchecked Sendable {
     }
 
     override func startLoading() {
-        guard let handler = MockURLProtocol.requestHandler else {
+        let id = request.value(forHTTPHeaderField: MockURLProtocol.sessionHeader) ?? ""
+        guard let handler = MockURLProtocol.handler(for: id) else {
             let error = NSError(domain: "MockURLProtocol", code: -1, userInfo: [
-                NSLocalizedDescriptionKey: "No request handler set"
+                NSLocalizedDescriptionKey: "No request handler set for session \(id)"
             ])
             client?.urlProtocol(self, didFailWithError: error)
             return
@@ -48,22 +82,46 @@ final class MockURLProtocol: URLProtocol, @unchecked Sendable {
     }
 
     override func stopLoading() {}
+}
 
-    /// Reset state between tests.
-    static func reset() {
-        requestHandler = nil
+// MARK: - Per-test mock session
+
+/// A test-scoped APIClient bound to its own MockURLProtocol handler slot. Each
+/// call to makeTestClient (and the token/artifact variants) gets a unique session
+/// id, so setting `mock.handler` only affects that client, even under parallel
+/// test execution.
+final class MockSession: @unchecked Sendable {
+    let id: String
+    let client: APIClient
+
+    init(baseURL: String) {
+        let id = UUID().uuidString
+        self.id = id
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        config.timeoutIntervalForRequest = 5
+        config.httpAdditionalHeaders = [MockURLProtocol.sessionHeader: id]
+        let session = URLSession(configuration: config)
+        self.client = APIClient(baseURL: baseURL, session: session)
     }
+
+    /// Install the stub handler for this session only.
+    var handler: MockRequestHandler? {
+        get { MockURLProtocol.handler(for: id) }
+        set {
+            if let newValue { MockURLProtocol.setHandler(for: id, newValue) }
+            else { MockURLProtocol.removeHandler(for: id) }
+        }
+    }
+
+    deinit { MockURLProtocol.removeHandler(for: id) }
 }
 
 // MARK: - Helper to create a testable APIClient
 
-/// Creates an APIClient that uses the MockURLProtocol for all requests.
-private func makeTestClient(baseURL: String = "https://test-api.example.com") -> APIClient {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    config.timeoutIntervalForRequest = 5
-    let session = URLSession(configuration: config)
-    return APIClient(baseURL: baseURL, session: session)
+/// Creates a MockSession (APIClient + isolated handler slot) for the network tests.
+private func makeTestSession(baseURL: String = "https://test-api.example.com") -> MockSession {
+    MockSession(baseURL: baseURL)
 }
 
 /// A simple Codable struct for testing generic request decoding.
@@ -79,20 +137,17 @@ struct TestRequestBody: Codable, Sendable {
     let value: Int
 }
 
-// All network tests use a shared MockURLProtocol, so they must run serially.
-@Suite("APIClient Network Tests", .serialized)
+// Each test uses its own MockSession (isolated handler slot), so the suite is
+// safe to run in parallel with others.
+@Suite("APIClient Network Tests")
 struct APIClientNetworkTests {
-
-    init() {
-        MockURLProtocol.reset()
-    }
 
     // MARK: - testConnection
 
     @Test func testConnectionSucceeds() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 200,
@@ -102,13 +157,13 @@ struct APIClientNetworkTests {
             return (response, Data("{\"status\": \"healthy\"}".utf8))
         }
 
-        try await client.testConnection(to: "https://test-api.example.com")
+        try await mock.client.testConnection(to: "https://test-api.example.com")
     }
 
     @Test func testConnectionFailsOnServerError() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 503,
@@ -119,7 +174,7 @@ struct APIClientNetworkTests {
         }
 
         do {
-            try await client.testConnection(to: "https://test-api.example.com")
+            try await mock.client.testConnection(to: "https://test-api.example.com")
             Issue.record("Expected httpError to be thrown")
         } catch {
             #expect(error is APIError)
@@ -127,9 +182,9 @@ struct APIClientNetworkTests {
     }
 
     @Test func testConnectionFailsOnInvalidURL() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
         do {
-            try await client.testConnection(to: "")
+            try await mock.client.testConnection(to: "")
             Issue.record("Expected error for empty URL")
         } catch {
             #expect(Bool(true))
@@ -137,9 +192,9 @@ struct APIClientNetworkTests {
     }
 
     @Test func testConnectionUsesCorrectTimeout() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.timeoutInterval == 10)
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -150,15 +205,15 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        try? await client.testConnection(to: "https://test-api.example.com")
+        try? await mock.client.testConnection(to: "https://test-api.example.com")
     }
 
     // MARK: - request<T> Tests
 
     @Test func requestDecodesSuccessfulResponse() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let json = """
             {"id": "42", "name": "Widget", "count": 10}
             """
@@ -171,17 +226,17 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let result: TestResponsePayload = try await client.request("/api/v1/items/42")
+        let result: TestResponsePayload = try await mock.client.request("/api/v1/items/42")
         #expect(result.id == "42")
         #expect(result.name == "Widget")
         #expect(result.count == 10)
     }
 
     @Test func requestIncludesBearerToken() async throws {
-        let client = makeTestClient()
-        await client.setToken("test-bearer-token")
+        let mock = makeTestSession()
+        await mock.client.setToken("test-bearer-token")
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let authHeader = request.value(forHTTPHeaderField: "Authorization")
             #expect(authHeader == "Bearer test-bearer-token")
             let json = """
@@ -196,13 +251,13 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let _: TestResponsePayload = try await client.request("/api/v1/items/1")
+        let _: TestResponsePayload = try await mock.client.request("/api/v1/items/1")
     }
 
     @Test func requestSendsNoAuthHeaderWithoutToken() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let authHeader = request.value(forHTTPHeaderField: "Authorization")
             #expect(authHeader == nil)
             let json = """
@@ -217,13 +272,13 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let _: TestResponsePayload = try await client.request("/api/v1/items/1")
+        let _: TestResponsePayload = try await mock.client.request("/api/v1/items/1")
     }
 
     @Test func requestSetsContentTypeJSON() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let contentType = request.value(forHTTPHeaderField: "Content-Type")
             #expect(contentType == "application/json")
             let json = """
@@ -238,13 +293,13 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let _: TestResponsePayload = try await client.request("/api/v1/test")
+        let _: TestResponsePayload = try await mock.client.request("/api/v1/test")
     }
 
     @Test func requestWithPOSTMethodAndBody() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "POST")
             let json = """
             {"id": "new", "name": "Created", "count": 42}
@@ -259,7 +314,7 @@ struct APIClientNetworkTests {
         }
 
         let body = TestRequestBody(action: "create", value: 42)
-        let result: TestResponsePayload = try await client.request(
+        let result: TestResponsePayload = try await mock.client.request(
             "/api/v1/items",
             method: "POST",
             body: body
@@ -268,9 +323,9 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestThrowsOnHTTP4xxError() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 404,
@@ -281,7 +336,7 @@ struct APIClientNetworkTests {
         }
 
         do {
-            let _: TestResponsePayload = try await client.request("/api/v1/items/missing")
+            let _: TestResponsePayload = try await mock.client.request("/api/v1/items/missing")
             Issue.record("Expected httpError")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 404")
@@ -291,9 +346,9 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestThrowsOnHTTP5xxError() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 500,
@@ -304,7 +359,7 @@ struct APIClientNetworkTests {
         }
 
         do {
-            let _: TestResponsePayload = try await client.request("/api/v1/items")
+            let _: TestResponsePayload = try await mock.client.request("/api/v1/items")
             Issue.record("Expected httpError")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 500")
@@ -314,10 +369,10 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestThrowsInvalidURLForEmptyBase() async {
-        let client = makeTestClient(baseURL: "")
+        let mock = makeTestSession(baseURL: "")
 
         do {
-            let _: TestResponsePayload = try await client.request("/api/v1/items")
+            let _: TestResponsePayload = try await mock.client.request("/api/v1/items")
             Issue.record("Expected invalidURL")
         } catch let error as APIError {
             #expect(error.errorDescription == "Invalid URL")
@@ -327,14 +382,14 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestWith401TriggersAuthFailureWhenNoRefreshHandler() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
         let tracker = AuthFailureTracker()
 
-        await client.setAuthFailureHandler {
+        await mock.client.setAuthFailureHandler {
             tracker.markCalled()
         }
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 401,
@@ -345,7 +400,7 @@ struct APIClientNetworkTests {
         }
 
         do {
-            let _: TestResponsePayload = try await client.request("/api/v1/protected")
+            let _: TestResponsePayload = try await mock.client.request("/api/v1/protected")
             Issue.record("Expected httpError")
         } catch {
             #expect(tracker.wasCalled == true)
@@ -353,12 +408,11 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestWith401RetriesAfterSuccessfulRefresh() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        var requestCount = 0
-        MockURLProtocol.requestHandler = { request in
-            requestCount += 1
-            if requestCount == 1 {
+        let requestCount = Counter()
+        mock.handler = { request in
+                        if requestCount.increment() == 1 {
                 let response = HTTPURLResponse(
                     url: request.url!,
                     statusCode: 401,
@@ -380,19 +434,19 @@ struct APIClientNetworkTests {
             }
         }
 
-        await client.setTokenRefreshHandler {
+        await mock.client.setTokenRefreshHandler {
             return true
         }
 
-        let result: TestResponsePayload = try await client.request("/api/v1/protected")
+        let result: TestResponsePayload = try await mock.client.request("/api/v1/protected")
         #expect(result.id == "retried")
-        #expect(requestCount == 2)
+        #expect(requestCount.count == 2)
     }
 
     @Test func requestWith401FailsWhenRefreshFails() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 401,
@@ -402,12 +456,12 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        await client.setTokenRefreshHandler {
+        await mock.client.setTokenRefreshHandler {
             return false
         }
 
         do {
-            let _: TestResponsePayload = try await client.request("/api/v1/protected")
+            let _: TestResponsePayload = try await mock.client.request("/api/v1/protected")
             Issue.record("Expected httpError 401")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 401")
@@ -417,9 +471,9 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestWithDELETEMethod() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "DELETE")
             let json = """
             {"id": "deleted", "name": "Gone", "count": 0}
@@ -433,14 +487,14 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let result: TestResponsePayload = try await client.request("/api/v1/items/1", method: "DELETE")
+        let result: TestResponsePayload = try await mock.client.request("/api/v1/items/1", method: "DELETE")
         #expect(result.id == "deleted")
     }
 
     @Test func requestWithPATCHMethod() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "PATCH")
             let json = """
             {"id": "patched", "name": "Updated", "count": 5}
@@ -454,7 +508,7 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let result: TestResponsePayload = try await client.request(
+        let result: TestResponsePayload = try await mock.client.request(
             "/api/v1/items/1",
             method: "PATCH",
             body: TestRequestBody(action: "update", value: 5)
@@ -463,9 +517,9 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestWithPUTMethod() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "PUT")
             let json = """
             {"id": "put", "name": "Replaced", "count": 99}
@@ -479,16 +533,16 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let result: TestResponsePayload = try await client.request("/api/v1/items/1", method: "PUT")
+        let result: TestResponsePayload = try await mock.client.request("/api/v1/items/1", method: "PUT")
         #expect(result.count == 99)
     }
 
     // MARK: - requestVoid Tests
 
     @Test func requestVoidSucceeds() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 204,
@@ -498,13 +552,13 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        try await client.requestVoid("/api/v1/items/1/archive")
+        try await mock.client.requestVoid("/api/v1/items/1/archive")
     }
 
     @Test func requestVoidThrowsOn4xx() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 403,
@@ -515,7 +569,7 @@ struct APIClientNetworkTests {
         }
 
         do {
-            try await client.requestVoid("/api/v1/admin/action")
+            try await mock.client.requestVoid("/api/v1/admin/action")
             Issue.record("Expected httpError 403")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 403")
@@ -525,9 +579,9 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestVoidThrowsOn5xx() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 502,
@@ -538,7 +592,7 @@ struct APIClientNetworkTests {
         }
 
         do {
-            try await client.requestVoid("/api/v1/action")
+            try await mock.client.requestVoid("/api/v1/action")
             Issue.record("Expected httpError 502")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 502")
@@ -548,10 +602,10 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestVoidThrowsInvalidURLForEmptyBase() async {
-        let client = makeTestClient(baseURL: "")
+        let mock = makeTestSession(baseURL: "")
 
         do {
-            try await client.requestVoid("/api/v1/action")
+            try await mock.client.requestVoid("/api/v1/action")
             Issue.record("Expected invalidURL")
         } catch let error as APIError {
             #expect(error.errorDescription == "Invalid URL")
@@ -561,14 +615,14 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestVoidWith401TriggersAuthFailure() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
         let tracker = AuthFailureTracker()
 
-        await client.setAuthFailureHandler {
+        await mock.client.setAuthFailureHandler {
             tracker.markCalled()
         }
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 401,
@@ -579,7 +633,7 @@ struct APIClientNetworkTests {
         }
 
         do {
-            try await client.requestVoid("/api/v1/protected")
+            try await mock.client.requestVoid("/api/v1/protected")
             Issue.record("Expected httpError 401")
         } catch {
             #expect(tracker.wasCalled == true)
@@ -587,12 +641,11 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestVoidWith401RetriesOnRefresh() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        var requestCount = 0
-        MockURLProtocol.requestHandler = { request in
-            requestCount += 1
-            let statusCode = requestCount == 1 ? 401 : 200
+        let requestCount = Counter()
+        mock.handler = { request in
+                        let statusCode = requestCount.increment() == 1 ? 401 : 200
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: statusCode,
@@ -602,18 +655,18 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        await client.setTokenRefreshHandler {
+        await mock.client.setTokenRefreshHandler {
             return true
         }
 
-        try await client.requestVoid("/api/v1/protected", method: "DELETE")
-        #expect(requestCount == 2)
+        try await mock.client.requestVoid("/api/v1/protected", method: "DELETE")
+        #expect(requestCount.count == 2)
     }
 
     @Test func requestVoidWith401FailsOnRefreshFailure() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 401,
@@ -623,12 +676,12 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        await client.setTokenRefreshHandler {
+        await mock.client.setTokenRefreshHandler {
             return false
         }
 
         do {
-            try await client.requestVoid("/api/v1/protected")
+            try await mock.client.requestVoid("/api/v1/protected")
             Issue.record("Expected httpError 401")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 401")
@@ -638,9 +691,9 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestVoidWithBody() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 200,
@@ -651,13 +704,13 @@ struct APIClientNetworkTests {
         }
 
         let body = TestRequestBody(action: "fire", value: 1)
-        try await client.requestVoid("/api/v1/trigger", method: "POST", body: body)
+        try await mock.client.requestVoid("/api/v1/trigger", method: "POST", body: body)
     }
 
     @Test func requestVoidWithDELETEMethod() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 204,
@@ -667,15 +720,15 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        try await client.requestVoid("/api/v1/items/1", method: "DELETE")
+        try await mock.client.requestVoid("/api/v1/items/1", method: "DELETE")
     }
 
     @Test func requestVoidWith401RetryButRetryAlsoFails() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
         var alwaysReturn401 = true
         _ = alwaysReturn401
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 401,
@@ -685,12 +738,12 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        await client.setTokenRefreshHandler {
+        await mock.client.setTokenRefreshHandler {
             return true // Refresh "succeeds" but retry also returns 401
         }
 
         do {
-            try await client.requestVoid("/api/v1/protected")
+            try await mock.client.requestVoid("/api/v1/protected")
             Issue.record("Expected httpError")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 401")
@@ -702,12 +755,11 @@ struct APIClientNetworkTests {
     // MARK: - 401 Retry Edge Cases
 
     @Test func requestRetryReturnsNewData() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        var attempt = 0
-        MockURLProtocol.requestHandler = { request in
-            attempt += 1
-            if attempt == 1 {
+        let attempt = Counter()
+        mock.handler = { request in
+                        if attempt.increment() == 1 {
                 let response = HTTPURLResponse(
                     url: request.url!,
                     statusCode: 401,
@@ -728,20 +780,19 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        await client.setTokenRefreshHandler { return true }
+        await mock.client.setTokenRefreshHandler { return true }
 
-        let result: TestResponsePayload = try await client.request("/api/v1/data")
+        let result: TestResponsePayload = try await mock.client.request("/api/v1/data")
         #expect(result.id == "refreshed")
         #expect(result.count == 99)
     }
 
     @Test func requestRetryWithFailedRetryResponse() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        var attempt = 0
-        MockURLProtocol.requestHandler = { request in
-            attempt += 1
-            if attempt == 1 {
+        let attempt = Counter()
+        mock.handler = { request in
+                        if attempt.increment() == 1 {
                 let response = HTTPURLResponse(
                     url: request.url!,
                     statusCode: 401,
@@ -760,10 +811,10 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        await client.setTokenRefreshHandler { return true }
+        await mock.client.setTokenRefreshHandler { return true }
 
         do {
-            let _: TestResponsePayload = try await client.request("/api/v1/data")
+            let _: TestResponsePayload = try await mock.client.request("/api/v1/data")
             Issue.record("Expected httpError")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 500")
@@ -773,12 +824,11 @@ struct APIClientNetworkTests {
     }
 
     @Test func requestVoidRetryWithFailedRetryResponse() async {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        var attempt = 0
-        MockURLProtocol.requestHandler = { request in
-            attempt += 1
-            if attempt == 1 {
+        let attempt = Counter()
+        mock.handler = { request in
+                        if attempt.increment() == 1 {
                 let response = HTTPURLResponse(
                     url: request.url!,
                     statusCode: 401,
@@ -797,10 +847,10 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        await client.setTokenRefreshHandler { return true }
+        await mock.client.setTokenRefreshHandler { return true }
 
         do {
-            try await client.requestVoid("/api/v1/data")
+            try await mock.client.requestVoid("/api/v1/data")
             Issue.record("Expected httpError")
         } catch let error as APIError {
             #expect(error.errorDescription == "HTTP error 500")
@@ -812,9 +862,9 @@ struct APIClientNetworkTests {
     // MARK: - Request with nil body
 
     @Test func requestWithNilBody() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpBody == nil)
             let json = """
             {"id": "nobody", "name": "NoBody", "count": 0}
@@ -828,14 +878,14 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let result: TestResponsePayload = try await client.request("/api/v1/items/1")
+        let result: TestResponsePayload = try await mock.client.request("/api/v1/items/1")
         #expect(result.id == "nobody")
     }
 
     @Test func requestVoidWithNilBody() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 200,
@@ -845,15 +895,15 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        try await client.requestVoid("/api/v1/items/1/touch", method: "POST")
+        try await mock.client.requestVoid("/api/v1/items/1/touch", method: "POST")
     }
 
     // MARK: - Higher-level API Method Tests
 
     @Test func updateProfileCallsRequestWithPUT() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "PUT")
             #expect(request.url?.path == "/api/v1/profile")
             let json = """
@@ -871,7 +921,7 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let profile = try await client.updateProfile(displayName: "New Name", email: "new@test.com")
+        let profile = try await mock.client.updateProfile(displayName: "New Name", email: "new@test.com")
         #expect(profile.displayName == "New Name")
     }
 
@@ -880,9 +930,9 @@ struct APIClientNetworkTests {
     // /api/v1/auth/tokens, delete via /api/v1/auth/tokens/{id}.
 
     @Test func listApiKeysCallsRequest() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let path = request.url?.path
             if path == "/api/v1/auth/me" {
                 let me = """
@@ -911,15 +961,15 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let keys = try await client.listApiKeys()
+        let keys = try await mock.client.listApiKeys()
         #expect(keys.count == 1)
         #expect(keys[0].name == "CI Key")
     }
 
     @Test func createApiKeyCallsRequest() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "POST")
             #expect(request.url?.path == "/api/v1/auth/tokens")
             let json = """
@@ -934,14 +984,14 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let result = try await client.createApiKey(name: "Deploy", scopes: ["write"], expiresInDays: 30)
+        let result = try await mock.client.createApiKey(name: "Deploy", scopes: ["write"], expiresInDays: 30)
         #expect(result.key == "ak_full_key_value")
     }
 
     @Test func deleteApiKeyCallsRequestVoid() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "DELETE")
             #expect(request.url?.path == "/api/v1/auth/tokens/key-123")
             let response = HTTPURLResponse(
@@ -953,13 +1003,13 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        try await client.deleteApiKey("key-123")
+        try await mock.client.deleteApiKey("key-123")
     }
 
     @Test func listAccessTokensCallsRequest() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let path = request.url?.path
             if path == "/api/v1/auth/me" {
                 let me = """
@@ -988,15 +1038,15 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let tokens = try await client.listAccessTokens()
+        let tokens = try await mock.client.listAccessTokens()
         #expect(tokens.count == 1)
         #expect(tokens[0].name == "Read Token")
     }
 
     @Test func createAccessTokenCallsRequest() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "POST")
             #expect(request.url?.path == "/api/v1/auth/tokens")
             let json = """
@@ -1011,14 +1061,14 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let result = try await client.createAccessToken(name: "CI Token", scopes: ["read", "write"], expiresInDays: nil)
+        let result = try await mock.client.createAccessToken(name: "CI Token", scopes: ["read", "write"], expiresInDays: nil)
         #expect(result.token == "at_full_token_value")
     }
 
     @Test func deleteAccessTokenCallsRequestVoid() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "DELETE")
             #expect(request.url?.path == "/api/v1/auth/tokens/token-456")
             let response = HTTPURLResponse(
@@ -1030,13 +1080,13 @@ struct APIClientNetworkTests {
             return (response, Data())
         }
 
-        try await client.deleteAccessToken("token-456")
+        try await mock.client.deleteAccessToken("token-456")
     }
 
     @Test func listStagingReposCallsRequest() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.url?.path == "/api/v1/staging/repositories")
             let json = """
             {"items": []}
@@ -1050,14 +1100,14 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let repos = try await client.listStagingRepos()
+        let repos = try await mock.client.listStagingRepos()
         #expect(repos.isEmpty)
     }
 
     @Test func getRepoSecurityConfigCallsRequest() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.url?.path == "/api/v1/repositories/maven-local/security")
             let json = """
             {
@@ -1079,14 +1129,14 @@ struct APIClientNetworkTests {
             return (response, Data(json.utf8))
         }
 
-        let config = try await client.getRepoSecurityConfig(repoKey: "maven-local")
+        let config = try await mock.client.getRepoSecurityConfig(repoKey: "maven-local")
         #expect(config.scanEnabled == true)
     }
 
     @Test func updateRepoSecurityConfigCallsRequest() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "PUT")
             let json = """
             {
@@ -1113,14 +1163,14 @@ struct APIClientNetworkTests {
             blockOnPolicyViolation: true,
             severityThreshold: "high"
         )
-        let result = try await client.updateRepoSecurityConfig(repoKey: "maven-local", config: config)
+        let result = try await mock.client.updateRepoSecurityConfig(repoKey: "maven-local", config: config)
         #expect(result.scanEnabled == true)
     }
 
     @Test func updateRepositoryCallsRequest() async throws {
-        let client = makeTestClient()
+        let mock = makeTestSession()
 
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             #expect(request.httpMethod == "PATCH")
             #expect(request.url?.path == "/api/v1/repositories/npm-local")
             let json = """
@@ -1146,7 +1196,7 @@ struct APIClientNetworkTests {
             description: "Updated repo",
             isPublic: false
         )
-        let repo = try await client.updateRepository(key: "npm-local", request: updateReq)
+        let repo = try await mock.client.updateRepository(key: "npm-local", request: updateReq)
         #expect(repo.name == "NPM Local Updated")
     }
 }

--- a/ArtifactKeeper/Tests/APIPathRegressionTests.swift
+++ b/ArtifactKeeper/Tests/APIPathRegressionTests.swift
@@ -29,27 +29,18 @@ private func okResponse(_ url: URL, _ body: String, status: Int = 200) -> (HTTPU
     return (response, Data(body.utf8))
 }
 
-/// Build an APIClient backed by MockURLProtocol. Defined locally because the
-/// equivalent helper in APIClientNetworkTests.swift is file-private.
-private func makeTokenTestClient(baseURL: String = "https://test-api.example.com") -> APIClient {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    config.timeoutIntervalForRequest = 5
-    let session = URLSession(configuration: config)
-    return APIClient(baseURL: baseURL, session: session)
+/// Build a per-test MockSession (APIClient + isolated handler slot).
+private func makeTokenTestSession(baseURL: String = "https://test-api.example.com") -> MockSession {
+    MockSession(baseURL: baseURL)
 }
 
-@Suite("API Token Path Regression Tests", .serialized)
+@Suite("API Token Path Regression Tests")
 struct APITokenPathRegressionTests {
 
-    init() {
-        MockURLProtocol.reset()
-    }
-
     @Test func listApiKeysTargetsUserTokensPath() async throws {
-        let client = makeTokenTestClient()
+        let mock = makeTokenTestSession()
         let recorder = PathRecorder()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let path = request.url!.path
             recorder.record(path)
             if path == "/api/v1/auth/me" {
@@ -60,23 +51,23 @@ struct APITokenPathRegressionTests {
             return okResponse(request.url!, "{\"items\": []}")
         }
 
-        _ = try await client.listApiKeys()
+        _ = try await mock.client.listApiKeys()
 
         #expect(recorder.paths.contains("/api/v1/users/user-7/tokens"))
         #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
     }
 
     @Test func createApiKeyTargetsAuthTokensPath() async throws {
-        let client = makeTokenTestClient()
+        let mock = makeTokenTestSession()
         let recorder = PathRecorder()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             recorder.record(request.url!.path)
             return okResponse(request.url!, """
             {"id": "tok-1", "name": "ci", "token": "ak_secretvalue"}
             """, status: 201)
         }
 
-        let result = try await client.createApiKey(name: "ci", scopes: ["read"], expiresInDays: 90)
+        let result = try await mock.client.createApiKey(name: "ci", scopes: ["read"], expiresInDays: 90)
 
         #expect(recorder.paths.contains("/api/v1/auth/tokens"))
         #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
@@ -84,23 +75,23 @@ struct APITokenPathRegressionTests {
     }
 
     @Test func deleteApiKeyTargetsAuthTokensPath() async throws {
-        let client = makeTokenTestClient()
+        let mock = makeTokenTestSession()
         let recorder = PathRecorder()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             recorder.record(request.url!.path)
             return okResponse(request.url!, "")
         }
 
-        try await client.deleteApiKey("tok-9")
+        try await mock.client.deleteApiKey("tok-9")
 
         #expect(recorder.paths.contains("/api/v1/auth/tokens/tok-9"))
         #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
     }
 
     @Test func listAccessTokensTargetsUserTokensPath() async throws {
-        let client = makeTokenTestClient()
+        let mock = makeTokenTestSession()
         let recorder = PathRecorder()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             let path = request.url!.path
             recorder.record(path)
             if path == "/api/v1/auth/me" {
@@ -111,23 +102,23 @@ struct APITokenPathRegressionTests {
             return okResponse(request.url!, "{\"items\": []}")
         }
 
-        _ = try await client.listAccessTokens()
+        _ = try await mock.client.listAccessTokens()
 
         #expect(recorder.paths.contains("/api/v1/users/user-9/tokens"))
         #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
     }
 
     @Test func createAccessTokenTargetsAuthTokensPath() async throws {
-        let client = makeTokenTestClient()
+        let mock = makeTokenTestSession()
         let recorder = PathRecorder()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             recorder.record(request.url!.path)
             return okResponse(request.url!, """
             {"id": "tok-2", "name": "deploy", "token": "ak_secretvalue2"}
             """, status: 201)
         }
 
-        let result = try await client.createAccessToken(name: "deploy", scopes: ["write"], expiresInDays: nil)
+        let result = try await mock.client.createAccessToken(name: "deploy", scopes: ["write"], expiresInDays: nil)
 
         #expect(recorder.paths.contains("/api/v1/auth/tokens"))
         #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))
@@ -135,14 +126,14 @@ struct APITokenPathRegressionTests {
     }
 
     @Test func deleteAccessTokenTargetsAuthTokensPath() async throws {
-        let client = makeTokenTestClient()
+        let mock = makeTokenTestSession()
         let recorder = PathRecorder()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             recorder.record(request.url!.path)
             return okResponse(request.url!, "")
         }
 
-        try await client.deleteAccessToken("tok-5")
+        try await mock.client.deleteAccessToken("tok-5")
 
         #expect(recorder.paths.contains("/api/v1/auth/tokens/tok-5"))
         #expect(!recorder.paths.contains(where: { $0.contains("/profile/") }))

--- a/ArtifactKeeper/Tests/ArtifactDetailTests.swift
+++ b/ArtifactKeeper/Tests/ArtifactDetailTests.swift
@@ -257,4 +257,13 @@ struct ArtifactDetailViewModelTests {
 
         #expect(called.paths.isEmpty)
     }
+
+    @Test @MainActor func downloadURLBuildsRepositoryDownloadPath() async {
+        let client = makeArtifactTestClient(baseURL: "https://reg.example.com")
+        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: client)
+
+        let url = await vm.downloadURL(repoKey: "maven-local", path: "com/x/1.0/x.jar")
+
+        #expect(url?.absoluteString == "https://reg.example.com/api/v1/repositories/maven-local/artifacts/com/x/1.0/x.jar/download")
+    }
 }

--- a/ArtifactKeeper/Tests/ArtifactDetailTests.swift
+++ b/ArtifactKeeper/Tests/ArtifactDetailTests.swift
@@ -13,12 +13,8 @@ private func artifactOk(_ url: URL, _ body: String, status: Int = 200) -> (HTTPU
     return (response, Data(body.utf8))
 }
 
-private func makeArtifactTestClient(baseURL: String = "https://test-api.example.com") -> APIClient {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    config.timeoutIntervalForRequest = 5
-    let session = URLSession(configuration: config)
-    return APIClient(baseURL: baseURL, session: session)
+private func makeArtifactTestSession(baseURL: String = "https://test-api.example.com") -> MockSession {
+    MockSession(baseURL: baseURL)
 }
 
 // Thread-safe path collector for assertions across multiple requests.
@@ -29,14 +25,13 @@ private final class ArtifactPathLog: @unchecked Sendable {
     var paths: [String] { lock.lock(); defer { lock.unlock() }; return values }
 }
 
-@Suite("Artifact Detail API Tests", .serialized)
+@Suite("Artifact Detail API Tests")
 struct ArtifactDetailAPITests {
-    init() { MockURLProtocol.reset() }
 
     @Test func getArtifactDetailHitsArtifactPathAndDecodes() async throws {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let log = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             log.add(request.url!.path)
             return artifactOk(request.url!, """
             {
@@ -48,7 +43,7 @@ struct ArtifactDetailAPITests {
             """)
         }
 
-        let detail = try await client.getArtifactDetail(id: "art-1")
+        let detail = try await mock.client.getArtifactDetail(id: "art-1")
 
         #expect(log.paths.contains("/api/v1/artifacts/art-1"))
         #expect(detail.id == "art-1")
@@ -59,16 +54,16 @@ struct ArtifactDetailAPITests {
     }
 
     @Test func getArtifactMetadataHitsMetadataPath() async throws {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let log = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             log.add(request.url!.path)
             return artifactOk(request.url!, """
             {"artifact_id": "art-1", "format": "maven", "metadata": {"group": "com.x"}, "properties": {"build": 42}}
             """)
         }
 
-        let meta = try await client.getArtifactMetadata(id: "art-1")
+        let meta = try await mock.client.getArtifactMetadata(id: "art-1")
 
         #expect(log.paths.contains("/api/v1/artifacts/art-1/metadata"))
         #expect(meta.format == "maven")
@@ -77,16 +72,16 @@ struct ArtifactDetailAPITests {
     }
 
     @Test func getArtifactStatsHitsStatsPath() async throws {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let log = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             log.add(request.url!.path)
             return artifactOk(request.url!, """
             {"artifact_id": "art-1", "download_count": 12, "first_downloaded": "2026-01-02T00:00:00Z", "last_downloaded": "2026-03-01T00:00:00Z"}
             """)
         }
 
-        let stats = try await client.getArtifactStats(id: "art-1")
+        let stats = try await mock.client.getArtifactStats(id: "art-1")
 
         #expect(log.paths.contains("/api/v1/artifacts/art-1/stats"))
         #expect(stats.downloadCount == 12)
@@ -94,16 +89,16 @@ struct ArtifactDetailAPITests {
     }
 
     @Test func listArtifactLabelsHitsLabelsPathAndDecodes() async throws {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let log = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             log.add(request.url!.path)
             return artifactOk(request.url!, """
             {"items": [{"id": "l1", "artifact_id": "art-1", "key": "env", "value": "prod", "created_at": "2026-01-01T00:00:00Z"}], "total": 1}
             """)
         }
 
-        let labels = try await client.listArtifactLabels(id: "art-1")
+        let labels = try await mock.client.listArtifactLabels(id: "art-1")
 
         #expect(log.paths.contains("/api/v1/artifacts/art-1/labels"))
         #expect(labels.count == 1)
@@ -112,9 +107,9 @@ struct ArtifactDetailAPITests {
     }
 
     @Test func addArtifactLabelPostsToKeyedPath() async throws {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let log = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             log.add(request.url!.path)
             #expect(request.httpMethod == "POST")
             return artifactOk(request.url!, """
@@ -122,7 +117,7 @@ struct ArtifactDetailAPITests {
             """, status: 201)
         }
 
-        let label = try await client.addArtifactLabel(id: "art-1", key: "team", value: "platform")
+        let label = try await mock.client.addArtifactLabel(id: "art-1", key: "team", value: "platform")
 
         #expect(log.paths.contains("/api/v1/artifacts/art-1/labels/team"))
         #expect(label.key == "team")
@@ -130,9 +125,9 @@ struct ArtifactDetailAPITests {
     }
 
     @Test func setArtifactLabelsPutsToLabelsPath() async throws {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let log = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             log.add(request.url!.path)
             #expect(request.httpMethod == "PUT")
             return artifactOk(request.url!, """
@@ -140,34 +135,33 @@ struct ArtifactDetailAPITests {
             """)
         }
 
-        let labels = try await client.setArtifactLabels(id: "art-1", labels: [ArtifactLabelEntry(key: "tier", value: "gold")])
+        let labels = try await mock.client.setArtifactLabels(id: "art-1", labels: [ArtifactLabelEntry(key: "tier", value: "gold")])
 
         #expect(log.paths.contains("/api/v1/artifacts/art-1/labels"))
         #expect(labels.first?.key == "tier")
     }
 
     @Test func deleteArtifactLabelDeletesKeyedPath() async throws {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let log = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             log.add(request.url!.path)
             #expect(request.httpMethod == "DELETE")
             return artifactOk(request.url!, "")
         }
 
-        try await client.deleteArtifactLabel(id: "art-1", key: "env")
+        try await mock.client.deleteArtifactLabel(id: "art-1", key: "env")
 
         #expect(log.paths.contains("/api/v1/artifacts/art-1/labels/env"))
     }
 }
 
-@Suite("Artifact Detail ViewModel Tests", .serialized)
+@Suite("Artifact Detail ViewModel Tests")
 struct ArtifactDetailViewModelTests {
-    init() { MockURLProtocol.reset() }
 
     @Test @MainActor func loadPopulatesDetailMetadataStatsAndLabels() async {
-        let client = makeArtifactTestClient()
-        MockURLProtocol.requestHandler = { request in
+        let mock = makeArtifactTestSession()
+        mock.handler = { request in
             let path = request.url!.path
             if path == "/api/v1/artifacts/art-9" {
                 return artifactOk(request.url!, """
@@ -192,7 +186,7 @@ struct ArtifactDetailViewModelTests {
             """)
         }
 
-        let vm = ArtifactDetailViewModel(artifactId: "art-9", api: client)
+        let vm = ArtifactDetailViewModel(artifactId: "art-9", api: mock.client)
         await vm.load()
 
         #expect(vm.detail?.id == "art-9")
@@ -204,12 +198,12 @@ struct ArtifactDetailViewModelTests {
     }
 
     @Test @MainActor func loadSetsErrorWhenDetailFails() async {
-        let client = makeArtifactTestClient()
-        MockURLProtocol.requestHandler = { request in
+        let mock = makeArtifactTestSession()
+        mock.handler = { request in
             return artifactOk(request.url!, "{\"error\":\"not found\"}", status: 404)
         }
 
-        let vm = ArtifactDetailViewModel(artifactId: "missing", api: client)
+        let vm = ArtifactDetailViewModel(artifactId: "missing", api: mock.client)
         await vm.load()
 
         #expect(vm.detail == nil)
@@ -218,9 +212,9 @@ struct ArtifactDetailViewModelTests {
     }
 
     @Test @MainActor func addLabelReloadsLabelSet() async {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let postCount = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             postCount.add(request.httpMethod ?? "")
             if request.httpMethod == "POST" {
                 return artifactOk(request.url!, """
@@ -236,7 +230,7 @@ struct ArtifactDetailViewModelTests {
             """)
         }
 
-        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: client)
+        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: mock.client)
         await vm.addLabel(key: "team", value: "platform")
 
         #expect(vm.labels.count == 2)
@@ -245,22 +239,22 @@ struct ArtifactDetailViewModelTests {
     }
 
     @Test @MainActor func addLabelIgnoresBlankKey() async {
-        let client = makeArtifactTestClient()
+        let mock = makeArtifactTestSession()
         let called = ArtifactPathLog()
-        MockURLProtocol.requestHandler = { request in
+        mock.handler = { request in
             called.add(request.url!.path)
             return artifactOk(request.url!, "{}")
         }
 
-        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: client)
+        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: mock.client)
         await vm.addLabel(key: "   ", value: "x")
 
         #expect(called.paths.isEmpty)
     }
 
     @Test @MainActor func downloadURLBuildsRepositoryDownloadPath() async {
-        let client = makeArtifactTestClient(baseURL: "https://reg.example.com")
-        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: client)
+        let mock = makeArtifactTestSession(baseURL: "https://reg.example.com")
+        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: mock.client)
 
         let url = await vm.downloadURL(repoKey: "maven-local", path: "com/x/1.0/x.jar")
 

--- a/ArtifactKeeper/Tests/ArtifactDetailTests.swift
+++ b/ArtifactKeeper/Tests/ArtifactDetailTests.swift
@@ -1,0 +1,260 @@
+import Testing
+import Foundation
+@testable import ArtifactKeeper
+
+// Covers the 1.2.1 Artifact Detail cluster: APIClient routing/decoding for
+// detail, metadata, stats and the artifact-labels CRUD, plus the view-model
+// load and label-mutation flows. Requests are stubbed via MockURLProtocol
+// (defined in APIClientNetworkTests.swift) and the path is captured to assert
+// the calls hit the 1.2.1 endpoints.
+
+private func artifactOk(_ url: URL, _ body: String, status: Int = 200) -> (HTTPURLResponse, Data) {
+    let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+    return (response, Data(body.utf8))
+}
+
+private func makeArtifactTestClient(baseURL: String = "https://test-api.example.com") -> APIClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    config.timeoutIntervalForRequest = 5
+    let session = URLSession(configuration: config)
+    return APIClient(baseURL: baseURL, session: session)
+}
+
+// Thread-safe path collector for assertions across multiple requests.
+private final class ArtifactPathLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String] = []
+    func add(_ p: String) { lock.lock(); values.append(p); lock.unlock() }
+    var paths: [String] { lock.lock(); defer { lock.unlock() }; return values }
+}
+
+@Suite("Artifact Detail API Tests", .serialized)
+struct ArtifactDetailAPITests {
+    init() { MockURLProtocol.reset() }
+
+    @Test func getArtifactDetailHitsArtifactPathAndDecodes() async throws {
+        let client = makeArtifactTestClient()
+        let log = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            log.add(request.url!.path)
+            return artifactOk(request.url!, """
+            {
+              "id": "art-1", "repository_key": "maven-local", "path": "com/x/1.0/x.jar",
+              "name": "x.jar", "version": "1.0", "content_type": "application/java-archive",
+              "size_bytes": 2048, "checksum_sha256": "abc", "download_count": 7,
+              "created_at": "2026-01-01T00:00:00Z", "cache_cached_at": null, "cache_expires_at": null
+            }
+            """)
+        }
+
+        let detail = try await client.getArtifactDetail(id: "art-1")
+
+        #expect(log.paths.contains("/api/v1/artifacts/art-1"))
+        #expect(detail.id == "art-1")
+        #expect(detail.repositoryKey == "maven-local")
+        #expect(detail.sizeBytes == 2048)
+        #expect(detail.downloadCount == 7)
+        #expect(detail.version == "1.0")
+    }
+
+    @Test func getArtifactMetadataHitsMetadataPath() async throws {
+        let client = makeArtifactTestClient()
+        let log = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            log.add(request.url!.path)
+            return artifactOk(request.url!, """
+            {"artifact_id": "art-1", "format": "maven", "metadata": {"group": "com.x"}, "properties": {"build": 42}}
+            """)
+        }
+
+        let meta = try await client.getArtifactMetadata(id: "art-1")
+
+        #expect(log.paths.contains("/api/v1/artifacts/art-1/metadata"))
+        #expect(meta.format == "maven")
+        #expect(meta.metadata?["group"]?.displayString == "com.x")
+        #expect(meta.properties?["build"]?.displayString == "42")
+    }
+
+    @Test func getArtifactStatsHitsStatsPath() async throws {
+        let client = makeArtifactTestClient()
+        let log = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            log.add(request.url!.path)
+            return artifactOk(request.url!, """
+            {"artifact_id": "art-1", "download_count": 12, "first_downloaded": "2026-01-02T00:00:00Z", "last_downloaded": "2026-03-01T00:00:00Z"}
+            """)
+        }
+
+        let stats = try await client.getArtifactStats(id: "art-1")
+
+        #expect(log.paths.contains("/api/v1/artifacts/art-1/stats"))
+        #expect(stats.downloadCount == 12)
+        #expect(stats.lastDownloaded == "2026-03-01T00:00:00Z")
+    }
+
+    @Test func listArtifactLabelsHitsLabelsPathAndDecodes() async throws {
+        let client = makeArtifactTestClient()
+        let log = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            log.add(request.url!.path)
+            return artifactOk(request.url!, """
+            {"items": [{"id": "l1", "artifact_id": "art-1", "key": "env", "value": "prod", "created_at": "2026-01-01T00:00:00Z"}], "total": 1}
+            """)
+        }
+
+        let labels = try await client.listArtifactLabels(id: "art-1")
+
+        #expect(log.paths.contains("/api/v1/artifacts/art-1/labels"))
+        #expect(labels.count == 1)
+        #expect(labels[0].key == "env")
+        #expect(labels[0].value == "prod")
+    }
+
+    @Test func addArtifactLabelPostsToKeyedPath() async throws {
+        let client = makeArtifactTestClient()
+        let log = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            log.add(request.url!.path)
+            #expect(request.httpMethod == "POST")
+            return artifactOk(request.url!, """
+            {"id": "l2", "artifact_id": "art-1", "key": "team", "value": "platform", "created_at": "2026-01-01T00:00:00Z"}
+            """, status: 201)
+        }
+
+        let label = try await client.addArtifactLabel(id: "art-1", key: "team", value: "platform")
+
+        #expect(log.paths.contains("/api/v1/artifacts/art-1/labels/team"))
+        #expect(label.key == "team")
+        #expect(label.value == "platform")
+    }
+
+    @Test func setArtifactLabelsPutsToLabelsPath() async throws {
+        let client = makeArtifactTestClient()
+        let log = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            log.add(request.url!.path)
+            #expect(request.httpMethod == "PUT")
+            return artifactOk(request.url!, """
+            {"items": [{"id": "l3", "artifact_id": "art-1", "key": "tier", "value": "gold", "created_at": "2026-01-01T00:00:00Z"}], "total": 1}
+            """)
+        }
+
+        let labels = try await client.setArtifactLabels(id: "art-1", labels: [ArtifactLabelEntry(key: "tier", value: "gold")])
+
+        #expect(log.paths.contains("/api/v1/artifacts/art-1/labels"))
+        #expect(labels.first?.key == "tier")
+    }
+
+    @Test func deleteArtifactLabelDeletesKeyedPath() async throws {
+        let client = makeArtifactTestClient()
+        let log = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            log.add(request.url!.path)
+            #expect(request.httpMethod == "DELETE")
+            return artifactOk(request.url!, "")
+        }
+
+        try await client.deleteArtifactLabel(id: "art-1", key: "env")
+
+        #expect(log.paths.contains("/api/v1/artifacts/art-1/labels/env"))
+    }
+}
+
+@Suite("Artifact Detail ViewModel Tests", .serialized)
+struct ArtifactDetailViewModelTests {
+    init() { MockURLProtocol.reset() }
+
+    @Test @MainActor func loadPopulatesDetailMetadataStatsAndLabels() async {
+        let client = makeArtifactTestClient()
+        MockURLProtocol.requestHandler = { request in
+            let path = request.url!.path
+            if path == "/api/v1/artifacts/art-9" {
+                return artifactOk(request.url!, """
+                {"id": "art-9", "repository_key": "npm-local", "path": "x/-/x-1.0.tgz", "name": "x-1.0.tgz",
+                 "version": "1.0", "content_type": "application/gzip", "size_bytes": 100, "checksum_sha256": "h",
+                 "download_count": 3, "created_at": "2026-01-01T00:00:00Z", "cache_cached_at": null, "cache_expires_at": null}
+                """)
+            }
+            if path == "/api/v1/artifacts/art-9/metadata" {
+                return artifactOk(request.url!, """
+                {"artifact_id": "art-9", "format": "npm", "metadata": {}, "properties": {}}
+                """)
+            }
+            if path == "/api/v1/artifacts/art-9/stats" {
+                return artifactOk(request.url!, """
+                {"artifact_id": "art-9", "download_count": 3, "first_downloaded": null, "last_downloaded": null}
+                """)
+            }
+            // labels
+            return artifactOk(request.url!, """
+            {"items": [{"id": "l1", "artifact_id": "art-9", "key": "env", "value": "dev", "created_at": "2026-01-01T00:00:00Z"}], "total": 1}
+            """)
+        }
+
+        let vm = ArtifactDetailViewModel(artifactId: "art-9", api: client)
+        await vm.load()
+
+        #expect(vm.detail?.id == "art-9")
+        #expect(vm.metadata?.format == "npm")
+        #expect(vm.stats?.downloadCount == 3)
+        #expect(vm.labels.count == 1)
+        #expect(vm.errorMessage == nil)
+        #expect(vm.isLoading == false)
+    }
+
+    @Test @MainActor func loadSetsErrorWhenDetailFails() async {
+        let client = makeArtifactTestClient()
+        MockURLProtocol.requestHandler = { request in
+            return artifactOk(request.url!, "{\"error\":\"not found\"}", status: 404)
+        }
+
+        let vm = ArtifactDetailViewModel(artifactId: "missing", api: client)
+        await vm.load()
+
+        #expect(vm.detail == nil)
+        #expect(vm.errorMessage != nil)
+        #expect(vm.isLoading == false)
+    }
+
+    @Test @MainActor func addLabelReloadsLabelSet() async {
+        let client = makeArtifactTestClient()
+        let postCount = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            postCount.add(request.httpMethod ?? "")
+            if request.httpMethod == "POST" {
+                return artifactOk(request.url!, """
+                {"id": "l2", "artifact_id": "art-1", "key": "team", "value": "platform", "created_at": "2026-01-01T00:00:00Z"}
+                """, status: 201)
+            }
+            // subsequent GET reload returns two labels
+            return artifactOk(request.url!, """
+            {"items": [
+              {"id": "l1", "artifact_id": "art-1", "key": "env", "value": "prod", "created_at": "2026-01-01T00:00:00Z"},
+              {"id": "l2", "artifact_id": "art-1", "key": "team", "value": "platform", "created_at": "2026-01-01T00:00:00Z"}
+            ], "total": 2}
+            """)
+        }
+
+        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: client)
+        await vm.addLabel(key: "team", value: "platform")
+
+        #expect(vm.labels.count == 2)
+        #expect(vm.labelError == nil)
+        #expect(postCount.paths.contains("POST"))
+    }
+
+    @Test @MainActor func addLabelIgnoresBlankKey() async {
+        let client = makeArtifactTestClient()
+        let called = ArtifactPathLog()
+        MockURLProtocol.requestHandler = { request in
+            called.add(request.url!.path)
+            return artifactOk(request.url!, "{}")
+        }
+
+        let vm = ArtifactDetailViewModel(artifactId: "art-1", api: client)
+        await vm.addLabel(key: "   ", value: "x")
+
+        #expect(called.paths.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
Builds the Artifact Detail experience against the v1.2.1 client surface: the highest-value cluster (Cluster 1 / Wave A) of the iOS Artifacts section. Replaces the static ArtifactDetailSheet (which only re-displayed list fields) with a full detail screen backed by a view model.

ArtifactDetailView + ArtifactDetailViewModel cover seven 1.2.1 operations plus a simple download action:
- GET /api/v1/artifacts/{id} (get_artifact)
- GET /api/v1/artifacts/{id}/metadata (get_artifact_metadata)
- GET /api/v1/artifacts/{id}/stats (get_artifact_stats)
- GET /api/v1/artifacts/{id}/labels (list_artifact_labels)
- PUT /api/v1/artifacts/{id}/labels (set_artifact_labels)
- POST /api/v1/artifacts/{id}/labels/{label_key} (add_artifact_label)
- DELETE /api/v1/artifacts/{id}/labels/{label_key} (delete_artifact_label)
- Simple Download-in-browser action via the existing buildDownloadURL helper (per the scope ruling allowing a trivial download when no streaming infra is needed).

Detail, metadata, stats and labels load concurrently and degrade independently. Labels can be added (key/value sheet) and removed (swipe). Both repository artifact lists present the new view.

### Deferred (per Artifacts scope rulings, separate later waves)
- Chunked upload sessions and raw PUT upload_artifact: deferred (not a mobile flow).
- delete_artifact: deferred to a later artifact-actions cluster.
- Repo-config WRITES (cache-ttl set, cache invalidate, routing-rules CUD, set-upstream-auth, test-upstream, pypi-tracks CUD): deferred to the Administration/repo-config wave. Reads are a later cluster.
- Curation rule authoring: deferred; moderation actions are a later cluster.

Implementation note: follows the dominant Features/* pattern of raw APIClient.request() with app-owned Codable models (repositories, packages, staging all do this), which keeps the layer uniform and fully testable via MockURLProtocol and avoids the generated-client property-name drift seen during the token work.

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

ArtifactDetailTests: 12 tests (TDD, Swift Testing). API routing/decoding for all seven endpoints, the download URL builder, and view-model load / detail-failure / label-add / blank-key flows. Full suite: 436 tests in 53 suites pass (xcodebuild test, ArtifactKeeper_macOS, platform=macOS). Build green.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements
- [ ] N/A - no UI changes

Closes #47
Part of #40