### PR TITLE
Security wave A: artifact-scoped scan results + SBOM (SDK-backed)

### DIFF
--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -649,6 +649,76 @@ actor APIClient {
         return try decoder.decode(Artifact.self, from: data)
     }
 
+    // MARK: Security Scans & Findings (SDK-backed)
+
+    /// List scans for a single artifact (GET /api/v1/security/artifacts/{artifact_id}/scans).
+    func listArtifactScans(artifactId: String) async throws -> [ScanResult] {
+        let client = await sdkClient.client
+        let response = try await client.list_artifact_scans(
+            path: .init(artifact_id: artifactId),
+            query: .init(per_page: 200)
+        )
+        let data = try response.ok.body.json
+        return data.items.map { ScanResult(from: $0) }
+    }
+
+    /// List scans, optionally filtered to a repository (GET /api/v1/security/scans).
+    func listScans(repositoryId: String? = nil) async throws -> [ScanResult] {
+        let client = await sdkClient.client
+        let response = try await client.list_scans(
+            query: .init(repository_id: repositoryId, per_page: 200)
+        )
+        let data = try response.ok.body.json
+        return data.items.map { ScanResult(from: $0) }
+    }
+
+    /// Fetch a single scan by id (GET /api/v1/security/scans/{id}).
+    func getScan(id: String) async throws -> ScanResult {
+        let client = await sdkClient.client
+        let response = try await client.get_scan(path: .init(id: id))
+        let data = try response.ok.body.json
+        return ScanResult(from: data)
+    }
+
+    /// List findings for a scan (GET /api/v1/security/scans/{id}/findings).
+    func listFindings(scanId: String) async throws -> [ScanFinding] {
+        let client = await sdkClient.client
+        let response = try await client.list_findings(
+            path: .init(id: scanId),
+            query: .init(per_page: 200)
+        )
+        let data = try response.ok.body.json
+        return data.items.map { ScanFinding(from: $0) }
+    }
+
+    // MARK: SBOM (SDK-backed)
+
+    /// Fetch the SBOM summary for an artifact (GET /api/v1/sbom/by-artifact/{artifact_id}).
+    func getSbomByArtifact(artifactId: String) async throws -> SbomSummary {
+        let client = await sdkClient.client
+        let response = try await client.get_sbom_by_artifact(
+            path: .init(artifact_id: artifactId)
+        )
+        let data = try response.ok.body.json
+        return SbomSummary(from: data)
+    }
+
+    /// Fetch a SBOM summary by id (GET /api/v1/sbom/{id}).
+    func getSbom(id: String) async throws -> SbomSummary {
+        let client = await sdkClient.client
+        let response = try await client.get_sbom(path: .init(id: id))
+        let data = try response.ok.body.json
+        return SbomSummary(from: data)
+    }
+
+    /// List the components in a SBOM (GET /api/v1/sbom/{id}/components).
+    func getSbomComponents(sbomId: String) async throws -> [SbomComponent] {
+        let client = await sdkClient.client
+        let response = try await client.get_sbom_components(path: .init(id: sbomId))
+        let data = try response.ok.body.json
+        return data.map { SbomComponent(from: $0) }
+    }
+
     // MARK: Repository Security Config
 
     func getRepoSecurityConfig(repoKey: String) async throws -> RepoSecurityConfig {

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -43,6 +43,23 @@ actor APIClient {
         self.decoder = JSONDecoder()
     }
 
+    /// Test-only override for the generated SDK client. When set, SDK-backed methods use
+    /// this client instead of the shared one, so a mock transport can assert the request
+    /// path and method (operation dispatch) without hitting the network.
+    private var injectedSDKClient: ArtifactKeeperClient.Client?
+
+    /// Inject a generated SDK client for tests. Production code never calls this.
+    func setSDKClientForTesting(_ client: ArtifactKeeperClient.Client) {
+        self.injectedSDKClient = client
+    }
+
+    /// The SDK client SDK-backed methods should use: the injected one in tests, otherwise
+    /// the shared client.
+    private func sdkClientInstance() async -> ArtifactKeeperClient.Client {
+        if let injectedSDKClient { return injectedSDKClient }
+        return await sdkClient.client
+    }
+
     func setToken(_ token: String?) {
         self.accessToken = token
         Task { await sdkClient.setToken(token) }
@@ -653,7 +670,7 @@ actor APIClient {
 
     /// List scans for a single artifact (GET /api/v1/security/artifacts/{artifact_id}/scans).
     func listArtifactScans(artifactId: String) async throws -> [ScanResult] {
-        let client = await sdkClient.client
+        let client = await sdkClientInstance()
         let response = try await client.list_artifact_scans(
             path: .init(artifact_id: artifactId),
             query: .init(per_page: 200)
@@ -662,27 +679,9 @@ actor APIClient {
         return data.items.map { ScanResult(from: $0) }
     }
 
-    /// List scans, optionally filtered to a repository (GET /api/v1/security/scans).
-    func listScans(repositoryId: String? = nil) async throws -> [ScanResult] {
-        let client = await sdkClient.client
-        let response = try await client.list_scans(
-            query: .init(repository_id: repositoryId, per_page: 200)
-        )
-        let data = try response.ok.body.json
-        return data.items.map { ScanResult(from: $0) }
-    }
-
-    /// Fetch a single scan by id (GET /api/v1/security/scans/{id}).
-    func getScan(id: String) async throws -> ScanResult {
-        let client = await sdkClient.client
-        let response = try await client.get_scan(path: .init(id: id))
-        let data = try response.ok.body.json
-        return ScanResult(from: data)
-    }
-
     /// List findings for a scan (GET /api/v1/security/scans/{id}/findings).
     func listFindings(scanId: String) async throws -> [ScanFinding] {
-        let client = await sdkClient.client
+        let client = await sdkClientInstance()
         let response = try await client.list_findings(
             path: .init(id: scanId),
             query: .init(per_page: 200)
@@ -695,7 +694,7 @@ actor APIClient {
 
     /// Fetch the SBOM summary for an artifact (GET /api/v1/sbom/by-artifact/{artifact_id}).
     func getSbomByArtifact(artifactId: String) async throws -> SbomSummary {
-        let client = await sdkClient.client
+        let client = await sdkClientInstance()
         let response = try await client.get_sbom_by_artifact(
             path: .init(artifact_id: artifactId)
         )
@@ -703,17 +702,9 @@ actor APIClient {
         return SbomSummary(from: data)
     }
 
-    /// Fetch a SBOM summary by id (GET /api/v1/sbom/{id}).
-    func getSbom(id: String) async throws -> SbomSummary {
-        let client = await sdkClient.client
-        let response = try await client.get_sbom(path: .init(id: id))
-        let data = try response.ok.body.json
-        return SbomSummary(from: data)
-    }
-
     /// List the components in a SBOM (GET /api/v1/sbom/{id}/components).
     func getSbomComponents(sbomId: String) async throws -> [SbomComponent] {
-        let client = await sdkClient.client
+        let client = await sdkClientInstance()
         let response = try await client.get_sbom_components(path: .init(id: sbomId))
         let data = try response.ok.body.json
         return data.map { SbomComponent(from: $0) }

--- a/ArtifactKeeper/Sources/Core/API/SecurityMapping.swift
+++ b/ArtifactKeeper/Sources/Core/API/SecurityMapping.swift
@@ -1,0 +1,130 @@
+import Foundation
+import ArtifactKeeperClient
+
+// MARK: - SDK -> App Model Mapping (Security / SBOM)
+//
+// The generated ArtifactKeeperClient returns strongly typed responses with snake_case
+// fields, Int32 counts and Foundation.Date timestamps. The app's view layer works with
+// the hand-written models in Core/Models (ScanResult, ScanFinding, SbomComponent, ...),
+// which use camelCase, Int counts and ISO8601 date strings. These initializers are the
+// single mapping point between the two so the conversions stay testable in isolation.
+
+extension ScanResult {
+    init(from sdk: Components.Schemas.ScanResponse) {
+        self.init(
+            id: sdk.id,
+            artifactId: sdk.artifact_id,
+            scanType: sdk.scan_type,
+            status: sdk.status,
+            findingsCount: Int(sdk.findings_count),
+            criticalCount: Int(sdk.critical_count),
+            highCount: Int(sdk.high_count),
+            mediumCount: Int(sdk.medium_count),
+            lowCount: Int(sdk.low_count),
+            startedAt: sdk.started_at.map(SecurityMapping.isoString),
+            completedAt: sdk.completed_at.map(SecurityMapping.isoString),
+            errorMessage: sdk.error_message,
+            artifactName: sdk.artifact_name,
+            artifactVersion: sdk.artifact_version
+        )
+    }
+}
+
+extension ScanFinding {
+    init(from sdk: Components.Schemas.FindingResponse) {
+        self.init(
+            id: sdk.id,
+            scanResultId: sdk.scan_result_id,
+            artifactId: sdk.artifact_id,
+            severity: sdk.severity,
+            title: sdk.title,
+            description: sdk.description,
+            cveId: sdk.cve_id,
+            affectedComponent: sdk.affected_component,
+            affectedVersion: sdk.affected_version,
+            fixedVersion: sdk.fixed_version,
+            source: sdk.source,
+            sourceUrl: sdk.source_url,
+            isAcknowledged: sdk.is_acknowledged,
+            acknowledgedBy: sdk.acknowledged_by,
+            acknowledgedReason: sdk.acknowledged_reason,
+            acknowledgedAt: sdk.acknowledged_at.map(SecurityMapping.isoString),
+            createdAt: SecurityMapping.isoString(sdk.created_at)
+        )
+    }
+}
+
+extension SbomComponent {
+    init(from sdk: Components.Schemas.ComponentResponse) {
+        self.init(
+            id: sdk.id,
+            sbomId: sdk.sbom_id,
+            name: sdk.name,
+            version: sdk.version,
+            purl: sdk.purl,
+            cpe: sdk.cpe,
+            componentType: sdk.component_type,
+            licenses: sdk.licenses,
+            sha256: sdk.sha256,
+            sha1: sdk.sha1,
+            md5: sdk.md5,
+            supplier: sdk.supplier,
+            author: sdk.author
+        )
+    }
+}
+
+/// SBOM summary mapped from the `SbomResponse` half of a `SbomContentResponse`.
+/// The view only needs the metadata (counts, format, licenses, generation info),
+/// not the raw document payload, so this carries the summary fields.
+struct SbomSummary: Identifiable, Sendable, Equatable {
+    let id: String
+    let artifactId: String
+    let repositoryId: String
+    let format: String
+    let formatVersion: String
+    let specVersion: String?
+    let componentCount: Int
+    let dependencyCount: Int
+    let licenseCount: Int
+    let licenses: [String]
+    let generator: String?
+    let generatorVersion: String?
+    let generatedAt: String
+
+    init(from sdk: Components.Schemas.SbomResponse) {
+        self.id = sdk.id
+        self.artifactId = sdk.artifact_id
+        self.repositoryId = sdk.repository_id
+        self.format = sdk.format
+        self.formatVersion = sdk.format_version
+        self.specVersion = sdk.spec_version
+        self.componentCount = Int(sdk.component_count)
+        self.dependencyCount = Int(sdk.dependency_count)
+        self.licenseCount = Int(sdk.license_count)
+        self.licenses = sdk.licenses
+        self.generator = sdk.generator
+        self.generatorVersion = sdk.generator_version
+        self.generatedAt = SecurityMapping.isoString(sdk.generated_at)
+    }
+}
+
+extension SbomSummary {
+    /// A `SbomContentResponse` is the SBOM metadata (`value1`) plus the raw document
+    /// payload (`value2`). The summary view only needs the metadata half.
+    init(from sdk: Components.Schemas.SbomContentResponse) {
+        self.init(from: sdk.value1)
+    }
+}
+
+// MARK: - Date Formatting
+
+enum SecurityMapping {
+    /// Render a `Foundation.Date` as an ISO8601 string with fractional seconds so it
+    /// round-trips through the existing string-based view formatters unchanged.
+    static func isoString(_ date: Foundation.Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Repositories/RepositoryDetailTabbedView.swift
+++ b/ArtifactKeeper/Sources/Features/Repositories/RepositoryDetailTabbedView.swift
@@ -67,7 +67,7 @@ struct RepositoryDetailTabbedView: View {
         }
         .sheet(item: $securityArtifact) { artifact in
             NavigationStack {
-                SbomView(artifactId: artifact.id, artifactName: artifact.name)
+                ArtifactSecurityHub(artifactId: artifact.id, artifactName: artifact.name)
                     .navigationTitle(artifact.name)
                     #if os(iOS)
                     .navigationBarTitleDisplayMode(.inline)

--- a/ArtifactKeeper/Sources/Features/Security/ArtifactSecurityView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/ArtifactSecurityView.swift
@@ -1,0 +1,457 @@
+import SwiftUI
+
+// Artifact-scoped security screens backed by the v1.2.1 ArtifactKeeperClient SDK.
+//
+// These cover the per-artifact half of the Security section that the repository-scoped
+// views in SecurityView.swift do not:
+//   - ArtifactScanResultsView: scans for one artifact          (list_artifact_scans)
+//   - ArtifactScanDetailView:  scan metadata + its findings    (get_scan, list_findings)
+//   - ArtifactSbomView:        SBOM summary + components        (get_sbom_by_artifact,
+//                                                                get_sbom, get_sbom_components)
+//
+// They reuse the shared row/badge components (ScanResultRow, SeverityPill, FindingRow,
+// GradeBadge) defined in SecurityView.swift and the SDK-backed APIClient methods.
+
+// MARK: - Artifact Security Hub
+
+/// Entry point for an artifact's security surfaces. Offers navigation into the SBOM
+/// and the scan results for the artifact.
+struct ArtifactSecurityHub: View {
+    let artifactId: String
+    let artifactName: String
+
+    var body: some View {
+        List {
+            Section {
+                NavigationLink {
+                    ArtifactScanResultsView(artifactId: artifactId, artifactName: artifactName)
+                } label: {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Scan Results")
+                            Text("Vulnerabilities and findings")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "ladybug")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                NavigationLink {
+                    ArtifactSbomView(artifactId: artifactId, artifactName: artifactName)
+                } label: {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Software Bill of Materials")
+                            Text("Components and licenses")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "doc.text.magnifyingglass")
+                            .foregroundStyle(.blue)
+                    }
+                }
+            } header: {
+                Text("Security")
+            }
+        }
+    }
+}
+
+// MARK: - Artifact Scan Results
+
+/// Lists the security scans for a single artifact.
+struct ArtifactScanResultsView: View {
+    let artifactId: String
+    let artifactName: String
+
+    @State private var scans: [ScanResult] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading scans...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                ContentUnavailableView {
+                    Label("Failed to Load", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Retry") { Task { await loadScans() } }
+                }
+            } else if scans.isEmpty {
+                ContentUnavailableView(
+                    "No Scans",
+                    systemImage: "checkmark.shield",
+                    description: Text("This artifact has not been scanned yet.")
+                )
+            } else {
+                List(scans) { scan in
+                    NavigationLink(destination: ArtifactScanDetailView(scan: scan)) {
+                        ScanResultRow(scan: scan)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .navigationTitle("Scans")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .refreshable { await loadScans() }
+        .task { await loadScans() }
+    }
+
+    private func loadScans() async {
+        isLoading = scans.isEmpty
+        do {
+            scans = try await apiClient.listArtifactScans(artifactId: artifactId)
+            errorMessage = nil
+        } catch {
+            if scans.isEmpty {
+                errorMessage = error.localizedDescription
+            }
+        }
+        isLoading = false
+    }
+}
+
+// MARK: - Artifact Scan Detail
+
+/// Shows a scan's severity breakdown and its findings.
+struct ArtifactScanDetailView: View {
+    let scan: ScanResult
+
+    @State private var findings: [ScanFinding] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading findings...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                ContentUnavailableView {
+                    Label("Failed to Load", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Retry") { Task { await loadFindings() } }
+                }
+            } else {
+                List {
+                    Section { summaryHeader }
+
+                    if findings.isEmpty {
+                        Section {
+                            ContentUnavailableView(
+                                "No Findings",
+                                systemImage: "checkmark.shield",
+                                description: Text("This scan did not produce any findings.")
+                            )
+                        }
+                    } else {
+                        Section("Findings (\(findings.count))") {
+                            ForEach(findings) { finding in
+                                FindingRow(finding: finding)
+                            }
+                        }
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .navigationTitle(scanTypeTitle)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .refreshable { await loadFindings() }
+        .task { await loadFindings() }
+    }
+
+    private var scanTypeTitle: String {
+        scan.scanType.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+
+    private var summaryHeader: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                if let name = scan.artifactName {
+                    Text(name)
+                        .font(.headline)
+                }
+                if let version = scan.artifactVersion {
+                    Text("v\(version)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(scan.status.capitalized)
+                    .font(.caption2.weight(.bold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(statusColor.opacity(0.15), in: Capsule())
+                    .foregroundStyle(statusColor)
+            }
+
+            HStack(spacing: 8) {
+                if scan.criticalCount > 0 {
+                    SeverityPill(count: scan.criticalCount, label: " Critical", color: .red)
+                }
+                if scan.highCount > 0 {
+                    SeverityPill(count: scan.highCount, label: " High", color: .orange)
+                }
+                if scan.mediumCount > 0 {
+                    SeverityPill(count: scan.mediumCount, label: " Medium", color: .yellow)
+                }
+                if scan.lowCount > 0 {
+                    SeverityPill(count: scan.lowCount, label: " Low", color: .blue)
+                }
+            }
+
+            Text("\(scan.findingsCount) total findings")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let error = scan.errorMessage, !error.isEmpty {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statusColor: Color {
+        switch scan.status {
+        case "completed": return .green
+        case "running", "pending": return .orange
+        case "failed": return .red
+        default: return .secondary
+        }
+    }
+
+    private func loadFindings() async {
+        isLoading = findings.isEmpty
+        do {
+            findings = try await apiClient.listFindings(scanId: scan.id)
+            errorMessage = nil
+        } catch {
+            if findings.isEmpty {
+                errorMessage = error.localizedDescription
+            }
+        }
+        isLoading = false
+    }
+}
+
+// MARK: - Artifact SBOM
+
+/// Shows the SBOM summary and component list for an artifact.
+struct ArtifactSbomView: View {
+    let artifactId: String
+    let artifactName: String
+
+    @State private var summary: SbomSummary?
+    @State private var components: [SbomComponent] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading SBOM...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                ContentUnavailableView {
+                    Label("Failed to Load", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Retry") { Task { await loadSbom() } }
+                }
+            } else if let summary {
+                content(summary: summary)
+            } else {
+                ContentUnavailableView(
+                    "No SBOM",
+                    systemImage: "doc.text.magnifyingglass",
+                    description: Text("No software bill of materials has been generated for this artifact.")
+                )
+            }
+        }
+        .navigationTitle("SBOM")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .refreshable { await loadSbom() }
+        .task { await loadSbom() }
+    }
+
+    @ViewBuilder
+    private func content(summary: SbomSummary) -> some View {
+        List {
+            Section {
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                    statBox("Format", summary.format.uppercased(), sub: "v\(summary.formatVersion)")
+                    statBox("Components", "\(summary.componentCount)")
+                    statBox("Dependencies", "\(summary.dependencyCount)")
+                    statBox("Licenses", "\(summary.licenseCount)")
+                }
+                .padding(.vertical, 4)
+
+                if let generator = summary.generator {
+                    HStack {
+                        Text("Generated by")
+                            .foregroundStyle(.secondary)
+                        Text(generator + (summary.generatorVersion.map { " \($0)" } ?? ""))
+                    }
+                    .font(.caption)
+                }
+            }
+
+            if !summary.licenses.isEmpty {
+                Section("Licenses") {
+                    ForEach(summary.licenses, id: \.self) { license in
+                        Label(license, systemImage: "doc.plaintext")
+                            .font(.subheadline)
+                    }
+                }
+            }
+
+            Section("Components (\(components.count))") {
+                if components.isEmpty {
+                    Text("No components recorded.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(components) { component in
+                        SbomComponentRow(component: component)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    private func statBox(_ label: String, _ value: String, sub: String? = nil) -> some View {
+        VStack(spacing: 4) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.title3.weight(.semibold))
+            if let sub {
+                Text(sub)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .background(.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func loadSbom() async {
+        isLoading = summary == nil
+        do {
+            let fetched = try await apiClient.getSbomByArtifact(artifactId: artifactId)
+            summary = fetched
+            components = try await apiClient.getSbomComponents(sbomId: fetched.id)
+            errorMessage = nil
+        } catch {
+            if summary == nil {
+                errorMessage = error.localizedDescription
+            }
+        }
+        isLoading = false
+    }
+}
+
+// MARK: - SBOM Component Row
+
+struct SbomComponentRow: View {
+    let component: SbomComponent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: "shippingbox")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(component.name)
+                    .font(.subheadline.weight(.medium))
+                    .lineLimit(1)
+
+                if let version = component.version {
+                    Text(version)
+                        .font(.caption.monospaced())
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.secondary.opacity(0.12), in: Capsule())
+                }
+
+                Spacer()
+
+                if let type = component.componentType {
+                    Text(type)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if !component.licenses.isEmpty {
+                Text(component.licenses.joined(separator: ", "))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if let purl = component.purl, !purl.isEmpty {
+                Text(purl)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview("Scan Detail") {
+    NavigationStack {
+        ArtifactScanDetailView(
+            scan: ScanResult(
+                id: "scan-1",
+                artifactId: "art-1",
+                scanType: "vulnerability",
+                status: "completed",
+                findingsCount: 3,
+                criticalCount: 1,
+                highCount: 1,
+                mediumCount: 1,
+                lowCount: 0,
+                startedAt: nil,
+                completedAt: nil,
+                errorMessage: nil,
+                artifactName: "libfoo",
+                artifactVersion: "1.2.3"
+            )
+        )
+    }
+}

--- a/ArtifactKeeper/Tests/SecurityDispatchTests.swift
+++ b/ArtifactKeeper/Tests/SecurityDispatchTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+import ArtifactKeeperClient
+@testable import ArtifactKeeper
+
+// Path-pinning tests for the SDK-backed Security/SBOM methods on APIClient.
+//
+// These assert the actual HTTP request path and method each APIClient method dispatches,
+// catching operation-dispatch drift (calling the wrong generated operation) that model
+// mapping tests cannot see. A recording transport captures the request and returns a
+// minimal valid body so the method decodes and returns normally.
+
+/// A ClientTransport that records the last request and replies with a canned 200 body
+/// keyed by operationID.
+final class RecordingTransport: ClientTransport, @unchecked Sendable {
+    struct Recorded: Sendable {
+        let path: String
+        let method: String
+        let operationID: String
+    }
+
+    private(set) var last: Recorded?
+
+    func send(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        last = Recorded(
+            path: request.path ?? "",
+            method: request.method.rawValue,
+            operationID: operationID
+        )
+
+        let json = Self.cannedBody(for: operationID)
+        var response = HTTPResponse(status: .ok)
+        response.headerFields[.contentType] = "application/json"
+        return (response, HTTPBody(json))
+    }
+
+    /// A 200 body for each operation. List/array shapes decode cleanly; for the SBOM
+    /// shape we return an empty object so decode fails after the request is recorded.
+    /// These are dispatch tests: the request is captured before the body is decoded, so a
+    /// decode failure does not affect the path/method assertions (callers use `try?`).
+    private static func cannedBody(for operationID: String) -> String {
+        switch operationID {
+        case "list_artifact_scans", "list_findings":
+            return #"{"items":[],"total":0}"#
+        case "get_sbom_components":
+            return "[]"
+        default:
+            return "{}"
+        }
+    }
+}
+
+/// The request path without its query string.
+private func pathComponent(_ path: String?) -> String {
+    guard let path else { return "" }
+    return String(path.split(separator: "?", maxSplits: 1)[0])
+}
+
+@Suite("Security SDK Dispatch Tests")
+struct SecurityDispatchTests {
+
+    /// Build an APIClient wired to a RecordingTransport via an injected SDK client.
+    private func makeClient() async -> (APIClient, RecordingTransport) {
+        let transport = RecordingTransport()
+        let sdk = Client(
+            serverURL: URL(string: "https://example.test")!,
+            transport: transport
+        )
+        let api = APIClient(baseURL: "https://example.test", session: .shared)
+        await api.setSDKClientForTesting(sdk)
+        return (api, transport)
+    }
+
+    @Test func listArtifactScansHitsArtifactScansPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try await api.listArtifactScans(artifactId: "abc123")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/security/artifacts/abc123/scans")
+        #expect(rec?.operationID == "list_artifact_scans")
+    }
+
+    @Test func listFindingsHitsScanFindingsPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try await api.listFindings(scanId: "scan-9")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/security/scans/scan-9/findings")
+        #expect(rec?.operationID == "list_findings")
+    }
+
+    @Test func getSbomByArtifactHitsByArtifactPath() async throws {
+        let (api, transport) = await makeClient()
+
+        // Decode of the canned body is irrelevant here: the transport records the request
+        // before the body is decoded, so `try?` keeps the dispatch assertions meaningful.
+        _ = try? await api.getSbomByArtifact(artifactId: "art-7")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/sbom/by-artifact/art-7")
+        #expect(rec?.operationID == "get_sbom_by_artifact")
+    }
+
+    @Test func getSbomComponentsHitsComponentsPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try await api.getSbomComponents(sbomId: "sbom-3")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/sbom/sbom-3/components")
+        #expect(rec?.operationID == "get_sbom_components")
+    }
+}

--- a/ArtifactKeeper/Tests/SecurityMappingTests.swift
+++ b/ArtifactKeeper/Tests/SecurityMappingTests.swift
@@ -1,0 +1,240 @@
+import Testing
+import Foundation
+import ArtifactKeeperClient
+@testable import ArtifactKeeper
+
+// Tests for the SDK -> app model mapping that backs the artifact-scoped Scan Results
+// and SBOM screens. These exercise the conversion in isolation (no live client), so a
+// drift in the generated SDK field shapes surfaces here rather than at runtime.
+
+@Suite("Security SDK Mapping Tests")
+struct SecurityMappingTests {
+
+    // A fixed instant used across the fixtures so the ISO8601 round-trip is assertable.
+    private static let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+    private static var fixedIso: String { SecurityMapping.isoString(fixedDate) }
+
+    // MARK: - ScanResult
+
+    @Test func scanResultMapsAllFields() {
+        let sdk = Components.Schemas.ScanResponse(
+            artifact_id: "art-1",
+            artifact_name: "libfoo",
+            artifact_version: "1.2.3",
+            completed_at: Self.fixedDate,
+            created_at: Self.fixedDate,
+            critical_count: 2,
+            error_message: nil,
+            findings_count: 7,
+            high_count: 3,
+            id: "scan-1",
+            info_count: 0,
+            is_reused: false,
+            low_count: 1,
+            medium_count: 1,
+            repository_id: "repo-1",
+            scan_type: "vulnerability",
+            scanner_version: "trivy-0.69",
+            started_at: Self.fixedDate,
+            status: "completed"
+        )
+
+        let model = ScanResult(from: sdk)
+
+        #expect(model.id == "scan-1")
+        #expect(model.artifactId == "art-1")
+        #expect(model.artifactName == "libfoo")
+        #expect(model.artifactVersion == "1.2.3")
+        #expect(model.scanType == "vulnerability")
+        #expect(model.status == "completed")
+        #expect(model.findingsCount == 7)
+        #expect(model.criticalCount == 2)
+        #expect(model.highCount == 3)
+        #expect(model.mediumCount == 1)
+        #expect(model.lowCount == 1)
+        #expect(model.completedAt == Self.fixedIso)
+        #expect(model.startedAt == Self.fixedIso)
+        #expect(model.errorMessage == nil)
+    }
+
+    @Test func scanResultMapsNilOptionals() {
+        let sdk = Components.Schemas.ScanResponse(
+            artifact_id: "art-2",
+            artifact_name: nil,
+            artifact_version: nil,
+            completed_at: nil,
+            created_at: Self.fixedDate,
+            critical_count: 0,
+            error_message: "scanner timed out",
+            findings_count: 0,
+            high_count: 0,
+            id: "scan-2",
+            info_count: 0,
+            is_reused: false,
+            low_count: 0,
+            medium_count: 0,
+            repository_id: "repo-2",
+            scan_type: "license",
+            scanner_version: nil,
+            started_at: nil,
+            status: "failed"
+        )
+
+        let model = ScanResult(from: sdk)
+
+        #expect(model.artifactName == nil)
+        #expect(model.artifactVersion == nil)
+        #expect(model.completedAt == nil)
+        #expect(model.startedAt == nil)
+        #expect(model.errorMessage == "scanner timed out")
+        #expect(model.status == "failed")
+    }
+
+    // MARK: - ScanFinding
+
+    @Test func scanFindingMapsAllFields() {
+        let sdk = Components.Schemas.FindingResponse(
+            acknowledged_at: Self.fixedDate,
+            acknowledged_by: "alice",
+            acknowledged_reason: "false positive",
+            affected_component: "openssl",
+            affected_version: "3.0.1",
+            artifact_id: "art-1",
+            created_at: Self.fixedDate,
+            cve_id: "CVE-2024-0001",
+            description: "A vulnerability",
+            fixed_version: "3.0.2",
+            id: "find-1",
+            is_acknowledged: true,
+            scan_result_id: "scan-1",
+            severity: "critical",
+            source: "trivy",
+            source_url: "https://example.com/cve",
+            title: "OpenSSL flaw"
+        )
+
+        let model = ScanFinding(from: sdk)
+
+        #expect(model.id == "find-1")
+        #expect(model.scanResultId == "scan-1")
+        #expect(model.artifactId == "art-1")
+        #expect(model.severity == "critical")
+        #expect(model.title == "OpenSSL flaw")
+        #expect(model.description == "A vulnerability")
+        #expect(model.cveId == "CVE-2024-0001")
+        #expect(model.affectedComponent == "openssl")
+        #expect(model.affectedVersion == "3.0.1")
+        #expect(model.fixedVersion == "3.0.2")
+        #expect(model.source == "trivy")
+        #expect(model.sourceUrl == "https://example.com/cve")
+        #expect(model.isAcknowledged == true)
+        #expect(model.acknowledgedBy == "alice")
+        #expect(model.acknowledgedReason == "false positive")
+        #expect(model.acknowledgedAt == Self.fixedIso)
+        #expect(model.createdAt == Self.fixedIso)
+    }
+
+    @Test func scanFindingMapsUnacknowledged() {
+        let sdk = Components.Schemas.FindingResponse(
+            acknowledged_at: nil,
+            acknowledged_by: nil,
+            acknowledged_reason: nil,
+            affected_component: nil,
+            affected_version: nil,
+            artifact_id: "art-3",
+            created_at: Self.fixedDate,
+            cve_id: nil,
+            description: nil,
+            fixed_version: nil,
+            id: "find-2",
+            is_acknowledged: false,
+            scan_result_id: "scan-3",
+            severity: "low",
+            source: nil,
+            source_url: nil,
+            title: "Minor issue"
+        )
+
+        let model = ScanFinding(from: sdk)
+
+        #expect(model.isAcknowledged == false)
+        #expect(model.acknowledgedAt == nil)
+        #expect(model.cveId == nil)
+        #expect(model.affectedComponent == nil)
+        #expect(model.severity == "low")
+    }
+
+    // MARK: - SbomComponent
+
+    @Test func sbomComponentMapsAllFields() {
+        let sdk = Components.Schemas.ComponentResponse(
+            author: "Foo Inc",
+            component_type: "library",
+            cpe: "cpe:2.3:a:foo",
+            id: "comp-1",
+            licenses: ["MIT", "Apache-2.0"],
+            md5: "md5hash",
+            name: "libfoo",
+            purl: "pkg:cargo/libfoo@1.0",
+            sbom_id: "sbom-1",
+            sha1: "sha1hash",
+            sha256: "sha256hash",
+            supplier: "vendor",
+            version: "1.0.0"
+        )
+
+        let model = SbomComponent(from: sdk)
+
+        #expect(model.id == "comp-1")
+        #expect(model.sbomId == "sbom-1")
+        #expect(model.name == "libfoo")
+        #expect(model.version == "1.0.0")
+        #expect(model.purl == "pkg:cargo/libfoo@1.0")
+        #expect(model.cpe == "cpe:2.3:a:foo")
+        #expect(model.componentType == "library")
+        #expect(model.licenses == ["MIT", "Apache-2.0"])
+        #expect(model.sha256 == "sha256hash")
+        #expect(model.sha1 == "sha1hash")
+        #expect(model.md5 == "md5hash")
+        #expect(model.supplier == "vendor")
+        #expect(model.author == "Foo Inc")
+    }
+
+    // MARK: - SbomSummary
+
+    @Test func sbomSummaryMapsFromResponse() {
+        let sdk = Components.Schemas.SbomResponse(
+            artifact_id: "art-1",
+            component_count: 42,
+            content_hash: "hash",
+            created_at: Self.fixedDate,
+            dependency_count: 40,
+            format: "cyclonedx",
+            format_version: "1.5",
+            generated_at: Self.fixedDate,
+            generator: "syft",
+            generator_version: "1.0",
+            id: "sbom-1",
+            license_count: 5,
+            licenses: ["MIT"],
+            repository_id: "repo-1",
+            spec_version: "1.5"
+        )
+
+        let model = SbomSummary(from: sdk)
+
+        #expect(model.id == "sbom-1")
+        #expect(model.artifactId == "art-1")
+        #expect(model.repositoryId == "repo-1")
+        #expect(model.format == "cyclonedx")
+        #expect(model.formatVersion == "1.5")
+        #expect(model.specVersion == "1.5")
+        #expect(model.componentCount == 42)
+        #expect(model.dependencyCount == 40)
+        #expect(model.licenseCount == 5)
+        #expect(model.licenses == ["MIT"])
+        #expect(model.generator == "syft")
+        #expect(model.generatorVersion == "1.0")
+        #expect(model.generatedAt == Self.fixedIso)
+    }
+}

--- a/docs/parity-matrix-1.2.1.md
+++ b/docs/parity-matrix-1.2.1.md
@@ -212,7 +212,7 @@ Status values:
 | quality | POST /api/v1/quality/issues/{id}/suppress | suppress_issue | missing | Security | - |  |
 | sbom | GET /api/v1/sbom | list_sboms | exists | Security | Sources/Features/Security/SbomView.swift | raw /api/v1/sbom |
 | sbom | POST /api/v1/sbom | generate_sbom | missing | Security | - |  |
-| sbom | GET /api/v1/sbom/by-artifact/{artifact_id} | get_sbom_by_artifact | missing | Security | - |  |
+| sbom | GET /api/v1/sbom/by-artifact/{artifact_id} | get_sbom_by_artifact | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK get_sbom_by_artifact |
 | sbom | POST /api/v1/sbom/check-compliance | check_license_compliance | missing | Security | - |  |
 | sbom | GET /api/v1/sbom/cve/history/by-artifact/{artifact_id} | get_cve_history_by_artifact | missing | Security | - |  |
 | sbom | GET /api/v1/sbom/cve/history/by-cve/{cve_id} | get_cve_history_by_cve | missing | Security | - |  |
@@ -225,8 +225,8 @@ Status values:
 | sbom | DELETE /api/v1/sbom/license-policies/{id} | delete_license_policy | missing | Security | - |  |
 | sbom | GET /api/v1/sbom/license-policies/{id} | get_license_policy | missing | Security | - |  |
 | sbom | DELETE /api/v1/sbom/{id} | delete_sbom | missing | Security | - |  |
-| sbom | GET /api/v1/sbom/{id} | get_sbom | exists | Security | Sources/Features/Security/SbomView.swift | raw /api/v1/sbom/{id} |
-| sbom | GET /api/v1/sbom/{id}/components | get_sbom_components | missing | Security | - |  |
+| sbom | GET /api/v1/sbom/{id} | get_sbom | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK get_sbom (APIClient.getSbom) |
+| sbom | GET /api/v1/sbom/{id}/components | get_sbom_components | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK get_sbom_components |
 | sbom | POST /api/v1/sbom/{id}/convert | convert_sbom | missing | Security | - |  |
 | security | PUT /api/v1/dependency-track/analysis | update_analysis | exists | Security | Sources/Features/Security/DtProjectsView.swift | raw PUT /api/v1/dependency-track/analysis |
 | security | GET /api/v1/dependency-track/metrics/portfolio | get_portfolio_metrics | exists | Security | Sources/Features/Security/SecurityView.swift | raw /api/v1/dependency-track/metrics/portfolio |
@@ -242,7 +242,7 @@ Status values:
 | security | GET /api/v1/repositories/{key}/security | get_repo_security | missing | Security | - |  |
 | security | PUT /api/v1/repositories/{key}/security | update_repo_security | missing | Security | - |  |
 | security | GET /api/v1/repositories/{key}/security/scans | list_repo_scans | missing | Security | - |  |
-| security | GET /api/v1/security/artifacts/{artifact_id}/scans | list_artifact_scans | missing | Security | - |  |
+| security | GET /api/v1/security/artifacts/{artifact_id}/scans | list_artifact_scans | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK list_artifact_scans |
 | security | GET /api/v1/security/configs | list_scan_configs | missing | Security | - |  |
 | security | GET /api/v1/security/dashboard | get_dashboard | missing | Security | - |  |
 | security | DELETE /api/v1/security/findings/{id}/acknowledge | revoke_acknowledgment | missing | Security | - |  |
@@ -253,9 +253,9 @@ Status values:
 | security | GET /api/v1/security/policies/{id} | get_policy | missing | Security | - |  |
 | security | PUT /api/v1/security/policies/{id} | update_policy | missing | Security | - |  |
 | security | POST /api/v1/security/scan | trigger_scan | missing | Security | - |  |
-| security | GET /api/v1/security/scans | list_scans | missing | Security | - |  |
-| security | GET /api/v1/security/scans/{id} | get_scan | missing | Security | - |  |
-| security | GET /api/v1/security/scans/{id}/findings | list_findings | missing | Security | - |  |
+| security | GET /api/v1/security/scans | list_scans | exists | Security | Sources/Core/API/APIClient.swift | SDK list_scans (APIClient.listScans) |
+| security | GET /api/v1/security/scans/{id} | get_scan | exists | Security | Sources/Core/API/APIClient.swift | SDK get_scan (APIClient.getScan) |
+| security | GET /api/v1/security/scans/{id}/findings | list_findings | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK list_findings |
 | security | GET /api/v1/security/scores | get_all_scores | missing | Security | - |  |
 | analytics | GET /api/v1/admin/analytics/artifacts/stale | get_stale_artifacts | missing | Operations | - |  |
 | analytics | GET /api/v1/admin/analytics/downloads/trend | get_download_trends | exists | Operations | Sources/Features/Operations/AnalyticsView.swift | raw /api/v1/admin/analytics/downloads/trend |
@@ -410,7 +410,7 @@ Status values:
 | Artifacts | 12 | 0 | 50 | 0 | 62 |
 | Staging | 0 | 3 | 18 | 0 | 21 |
 | Integration | 6 | 0 | 94 | 0 | 100 |
-| Security | 9 | 0 | 53 | 0 | 62 |
+| Security | 16 | 0 | 46 | 0 | 62 |
 | Operations | 6 | 0 | 25 | 6 | 37 |
 | Administration | 12 | 0 | 61 | 13 | 86 |
 | Cross-cutting | 9 | 5 | 8 | 0 | 22 |

--- a/docs/parity-matrix-1.2.1.md
+++ b/docs/parity-matrix-1.2.1.md
@@ -212,7 +212,7 @@ Status values:
 | quality | POST /api/v1/quality/issues/{id}/suppress | suppress_issue | missing | Security | - |  |
 | sbom | GET /api/v1/sbom | list_sboms | exists | Security | Sources/Features/Security/SbomView.swift | raw /api/v1/sbom |
 | sbom | POST /api/v1/sbom | generate_sbom | missing | Security | - |  |
-| sbom | GET /api/v1/sbom/by-artifact/{artifact_id} | get_sbom_by_artifact | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK get_sbom_by_artifact |
+| sbom | GET /api/v1/sbom/by-artifact/{artifact_id} | get_sbom_by_artifact | missing | Security | - |  |
 | sbom | POST /api/v1/sbom/check-compliance | check_license_compliance | missing | Security | - |  |
 | sbom | GET /api/v1/sbom/cve/history/by-artifact/{artifact_id} | get_cve_history_by_artifact | missing | Security | - |  |
 | sbom | GET /api/v1/sbom/cve/history/by-cve/{cve_id} | get_cve_history_by_cve | missing | Security | - |  |
@@ -225,8 +225,8 @@ Status values:
 | sbom | DELETE /api/v1/sbom/license-policies/{id} | delete_license_policy | missing | Security | - |  |
 | sbom | GET /api/v1/sbom/license-policies/{id} | get_license_policy | missing | Security | - |  |
 | sbom | DELETE /api/v1/sbom/{id} | delete_sbom | missing | Security | - |  |
-| sbom | GET /api/v1/sbom/{id} | get_sbom | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK get_sbom (APIClient.getSbom) |
-| sbom | GET /api/v1/sbom/{id}/components | get_sbom_components | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK get_sbom_components |
+| sbom | GET /api/v1/sbom/{id} | get_sbom | exists | Security | Sources/Features/Security/SbomView.swift | raw /api/v1/sbom/{id} |
+| sbom | GET /api/v1/sbom/{id}/components | get_sbom_components | missing | Security | - |  |
 | sbom | POST /api/v1/sbom/{id}/convert | convert_sbom | missing | Security | - |  |
 | security | PUT /api/v1/dependency-track/analysis | update_analysis | exists | Security | Sources/Features/Security/DtProjectsView.swift | raw PUT /api/v1/dependency-track/analysis |
 | security | GET /api/v1/dependency-track/metrics/portfolio | get_portfolio_metrics | exists | Security | Sources/Features/Security/SecurityView.swift | raw /api/v1/dependency-track/metrics/portfolio |
@@ -242,7 +242,7 @@ Status values:
 | security | GET /api/v1/repositories/{key}/security | get_repo_security | missing | Security | - |  |
 | security | PUT /api/v1/repositories/{key}/security | update_repo_security | missing | Security | - |  |
 | security | GET /api/v1/repositories/{key}/security/scans | list_repo_scans | missing | Security | - |  |
-| security | GET /api/v1/security/artifacts/{artifact_id}/scans | list_artifact_scans | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK list_artifact_scans |
+| security | GET /api/v1/security/artifacts/{artifact_id}/scans | list_artifact_scans | missing | Security | - |  |
 | security | GET /api/v1/security/configs | list_scan_configs | missing | Security | - |  |
 | security | GET /api/v1/security/dashboard | get_dashboard | missing | Security | - |  |
 | security | DELETE /api/v1/security/findings/{id}/acknowledge | revoke_acknowledgment | missing | Security | - |  |
@@ -253,9 +253,9 @@ Status values:
 | security | GET /api/v1/security/policies/{id} | get_policy | missing | Security | - |  |
 | security | PUT /api/v1/security/policies/{id} | update_policy | missing | Security | - |  |
 | security | POST /api/v1/security/scan | trigger_scan | missing | Security | - |  |
-| security | GET /api/v1/security/scans | list_scans | exists | Security | Sources/Core/API/APIClient.swift | SDK list_scans (APIClient.listScans) |
-| security | GET /api/v1/security/scans/{id} | get_scan | exists | Security | Sources/Core/API/APIClient.swift | SDK get_scan (APIClient.getScan) |
-| security | GET /api/v1/security/scans/{id}/findings | list_findings | exists | Security | Sources/Features/Security/ArtifactSecurityView.swift | SDK list_findings |
+| security | GET /api/v1/security/scans | list_scans | missing | Security | - |  |
+| security | GET /api/v1/security/scans/{id} | get_scan | missing | Security | - |  |
+| security | GET /api/v1/security/scans/{id}/findings | list_findings | missing | Security | - |  |
 | security | GET /api/v1/security/scores | get_all_scores | missing | Security | - |  |
 | analytics | GET /api/v1/admin/analytics/artifacts/stale | get_stale_artifacts | missing | Operations | - |  |
 | analytics | GET /api/v1/admin/analytics/downloads/trend | get_download_trends | exists | Operations | Sources/Features/Operations/AnalyticsView.swift | raw /api/v1/admin/analytics/downloads/trend |
@@ -410,7 +410,7 @@ Status values:
 | Artifacts | 12 | 0 | 50 | 0 | 62 |
 | Staging | 0 | 3 | 18 | 0 | 21 |
 | Integration | 6 | 0 | 94 | 0 | 100 |
-| Security | 16 | 0 | 46 | 0 | 62 |
+| Security | 9 | 0 | 53 | 0 | 62 |
 | Operations | 6 | 0 | 25 | 6 | 37 |
 | Administration | 12 | 0 | 61 | 13 | 86 |
 | Cross-cutting | 9 | 5 | 8 | 0 | 22 |


### PR DESCRIPTION
## Summary

Adds the per-artifact Security cluster to the iOS/macOS app, wired to the v1.2.1 ArtifactKeeperClient SDK. Wave A of the Security section parity work (#40).

Screens:
- Artifact Security hub (presented from an artifact): navigates to Scans and SBOM
- Artifact scan results list -> scan detail with severity-color-coded findings
- Artifact SBOM: summary stats (format, components, dependencies, licenses) + component list

SDK-backed methods added to `APIClient` map generated responses onto the existing app models. The conversion is isolated in `Core/API/SecurityMapping.swift` (new `SbomSummary` model plus `init(from:)` mappers for `ScanResult`, `ScanFinding`, `SbomComponent`) and unit-tested without a live client.

### Operations covered (4 wired + tested rows, Section == Security)

| operationId | method + path | screen |
|-------------|---------------|--------|
| list_artifact_scans | GET /api/v1/security/artifacts/{id}/scans | ArtifactScanResultsView |
| list_findings | GET /api/v1/security/scans/{id}/findings | ArtifactScanDetailView |
| get_sbom_by_artifact | GET /api/v1/sbom/by-artifact/{id} | ArtifactSbomView |
| get_sbom_components | GET /api/v1/sbom/{id}/components | ArtifactSbomView |

Only operations reachable from a screen are claimed. Earlier uncalled APIClient methods (get_scan, list_scans, get_sbom) were removed rather than left as dead code.

Native UX: semantic severity colors, loading/empty/error states with retry, SF Symbols, Dynamic Type friendly layouts, dark mode, macOS-guarded title display mode.

Closes #49
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Tests (Swift Testing):
- `SecurityMappingTests` (6) cover all SDK -> model mappings, including nil-optional paths.
- `SecurityDispatchTests` (4) are path-pinning tests: a per-instance recording transport asserts the actual request path, method and operationId for each wired method. No shared global state, so they pass under parallel execution.

Full suite: 434 tests pass serially. Under parallel `swift test`, the only failures are the pre-existing `APIClient Network Tests` (shared `MockURLProtocol` static; the file is annotated "must run serially" and is being made parallel-safe separately on the artifacts branch). This PR's new tests pass in both modes.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [x] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements
- [ ] N/A - no UI changes