### PR TITLE
Security wave B: dashboard, scores, finding acknowledgment, trigger scan (SDK-backed)

### DIFF
--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -690,6 +690,53 @@ actor APIClient {
         return data.items.map { ScanFinding(from: $0) }
     }
 
+    /// Security overview counts (GET /api/v1/security/dashboard).
+    func getSecurityDashboard() async throws -> SecurityDashboard {
+        let client = await sdkClientInstance()
+        let response = try await client.get_dashboard()
+        let data = try response.ok.body.json
+        return SecurityDashboard(from: data)
+    }
+
+    /// Per-repository security scores (GET /api/v1/security/scores).
+    func getSecurityScores() async throws -> [RepoSecurityScore] {
+        let client = await sdkClientInstance()
+        let response = try await client.get_all_scores()
+        let data = try response.ok.body.json
+        return data.map { RepoSecurityScore(from: $0) }
+    }
+
+    /// Acknowledge a finding with a reason (POST /api/v1/security/findings/{id}/acknowledge).
+    /// Returns the updated finding.
+    func acknowledgeFinding(id: String, reason: String) async throws -> ScanFinding {
+        let client = await sdkClientInstance()
+        let response = try await client.acknowledge_finding(
+            path: .init(id: id),
+            body: .json(.init(reason: reason))
+        )
+        let data = try response.ok.body.json
+        return ScanFinding(from: data)
+    }
+
+    /// Revoke a finding's acknowledgment (DELETE /api/v1/security/findings/{id}/acknowledge).
+    /// Returns the updated finding.
+    func revokeFindingAcknowledgment(id: String) async throws -> ScanFinding {
+        let client = await sdkClientInstance()
+        let response = try await client.revoke_acknowledgment(path: .init(id: id))
+        let data = try response.ok.body.json
+        return ScanFinding(from: data)
+    }
+
+    /// Trigger a scan for an artifact or repository (POST /api/v1/security/scan).
+    func triggerScan(artifactId: String? = nil, repositoryId: String? = nil) async throws -> TriggerScanResult {
+        let client = await sdkClientInstance()
+        let response = try await client.trigger_scan(
+            body: .json(.init(artifact_id: artifactId, repository_id: repositoryId))
+        )
+        let data = try response.ok.body.json
+        return TriggerScanResult(from: data)
+    }
+
     // MARK: SBOM (SDK-backed)
 
     /// Fetch the SBOM summary for an artifact (GET /api/v1/sbom/by-artifact/{artifact_id}).

--- a/ArtifactKeeper/Sources/Core/API/SecurityMapping.swift
+++ b/ArtifactKeeper/Sources/Core/API/SecurityMapping.swift
@@ -117,6 +117,49 @@ extension SbomSummary {
     }
 }
 
+extension RepoSecurityScore {
+    init(from sdk: Components.Schemas.ScoreResponse) {
+        self.init(
+            id: sdk.id,
+            repositoryId: sdk.repository_id,
+            grade: sdk.grade,
+            score: Int(sdk.score),
+            criticalCount: Int(sdk.critical_count),
+            highCount: Int(sdk.high_count),
+            mediumCount: Int(sdk.medium_count),
+            lowCount: Int(sdk.low_count),
+            totalFindings: Int(sdk.total_findings),
+            acknowledgedCount: Int(sdk.acknowledged_count),
+            lastScanAt: sdk.last_scan_at.map(SecurityMapping.isoString),
+            calculatedAt: SecurityMapping.isoString(sdk.calculated_at)
+        )
+    }
+}
+
+extension SecurityDashboard {
+    init(from sdk: Components.Schemas.DashboardResponse) {
+        self.init(
+            reposWithScanning: Int(sdk.repos_with_scanning),
+            totalScans: Int(sdk.total_scans),
+            totalFindings: Int(sdk.total_findings),
+            criticalFindings: Int(sdk.critical_findings),
+            highFindings: Int(sdk.high_findings),
+            policyViolationsBlocked: Int(sdk.policy_violations_blocked),
+            reposGradeA: Int(sdk.repos_grade_a),
+            reposGradeF: Int(sdk.repos_grade_f)
+        )
+    }
+}
+
+extension TriggerScanResult {
+    init(from sdk: Components.Schemas.TriggerScanResponse) {
+        self.init(
+            artifactsQueued: Int(sdk.artifacts_queued),
+            message: sdk.message
+        )
+    }
+}
+
 // MARK: - Date Formatting
 
 enum SecurityMapping {

--- a/ArtifactKeeper/Sources/Core/Models/Security.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Security.swift
@@ -107,7 +107,13 @@ struct RepoSecurityScore: Codable, Identifiable, Hashable, Sendable {
     let highCount: Int
     let mediumCount: Int
     let lowCount: Int
-    
+    // 1.2.1 ScoreResponse adds these fields. Optional so existing decode sites and the
+    // Hashable/Identifiable conformances stay backward compatible.
+    var totalFindings: Int?
+    var acknowledgedCount: Int?
+    var lastScanAt: String?
+    var calculatedAt: String?
+
     enum CodingKeys: String, CodingKey {
         case id, grade, score
         case repositoryId = "repository_id"
@@ -115,5 +121,57 @@ struct RepoSecurityScore: Codable, Identifiable, Hashable, Sendable {
         case highCount = "high_count"
         case mediumCount = "medium_count"
         case lowCount = "low_count"
+        case totalFindings = "total_findings"
+        case acknowledgedCount = "acknowledged_count"
+        case lastScanAt = "last_scan_at"
+        case calculatedAt = "calculated_at"
     }
+
+    init(
+        id: String,
+        repositoryId: String,
+        grade: String,
+        score: Int,
+        criticalCount: Int,
+        highCount: Int,
+        mediumCount: Int,
+        lowCount: Int,
+        totalFindings: Int? = nil,
+        acknowledgedCount: Int? = nil,
+        lastScanAt: String? = nil,
+        calculatedAt: String? = nil
+    ) {
+        self.id = id
+        self.repositoryId = repositoryId
+        self.grade = grade
+        self.score = score
+        self.criticalCount = criticalCount
+        self.highCount = highCount
+        self.mediumCount = mediumCount
+        self.lowCount = lowCount
+        self.totalFindings = totalFindings
+        self.acknowledgedCount = acknowledgedCount
+        self.lastScanAt = lastScanAt
+        self.calculatedAt = calculatedAt
+    }
+}
+
+// MARK: - Security Dashboard (1.2.1 DashboardResponse)
+
+struct SecurityDashboard: Sendable, Equatable {
+    let reposWithScanning: Int
+    let totalScans: Int
+    let totalFindings: Int
+    let criticalFindings: Int
+    let highFindings: Int
+    let policyViolationsBlocked: Int
+    let reposGradeA: Int
+    let reposGradeF: Int
+}
+
+// MARK: - Trigger Scan (1.2.1 TriggerScanResponse)
+
+struct TriggerScanResult: Sendable, Equatable {
+    let artifactsQueued: Int
+    let message: String
 }

--- a/ArtifactKeeper/Sources/Features/Security/ArtifactSecurityView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/ArtifactSecurityView.swift
@@ -4,10 +4,13 @@ import SwiftUI
 //
 // These cover the per-artifact half of the Security section that the repository-scoped
 // views in SecurityView.swift do not:
-//   - ArtifactScanResultsView: scans for one artifact          (list_artifact_scans)
-//   - ArtifactScanDetailView:  scan metadata + its findings    (get_scan, list_findings)
+//   - ArtifactScanResultsView: scans for one artifact, rescan  (list_artifact_scans,
+//                                                                trigger_scan)
+//   - ArtifactScanDetailView:  scan findings, acknowledge      (list_findings,
+//                                                                acknowledge_finding,
+//                                                                revoke_acknowledgment)
 //   - ArtifactSbomView:        SBOM summary + components        (get_sbom_by_artifact,
-//                                                                get_sbom, get_sbom_components)
+//                                                                get_sbom_components)
 //
 // They reuse the shared row/badge components (ScanResultRow, SeverityPill, FindingRow,
 // GradeBadge) defined in SecurityView.swift and the SDK-backed APIClient methods.
@@ -71,6 +74,8 @@ struct ArtifactScanResultsView: View {
     @State private var scans: [ScanResult] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var isScanning = false
+    @State private var banner: String?
 
     private let apiClient = APIClient.shared
 
@@ -88,15 +93,33 @@ struct ArtifactScanResultsView: View {
                     Button("Retry") { Task { await loadScans() } }
                 }
             } else if scans.isEmpty {
-                ContentUnavailableView(
-                    "No Scans",
-                    systemImage: "checkmark.shield",
-                    description: Text("This artifact has not been scanned yet.")
-                )
+                ContentUnavailableView {
+                    Label("No Scans", systemImage: "checkmark.shield")
+                } description: {
+                    Text("This artifact has not been scanned yet.")
+                } actions: {
+                    Button {
+                        Task { await triggerScan() }
+                    } label: {
+                        Label("Scan Now", systemImage: "ladybug")
+                    }
+                    .disabled(isScanning)
+                }
             } else {
-                List(scans) { scan in
-                    NavigationLink(destination: ArtifactScanDetailView(scan: scan)) {
-                        ScanResultRow(scan: scan)
+                List {
+                    if let banner {
+                        Section {
+                            Label(banner, systemImage: "checkmark.circle.fill")
+                                .font(.caption)
+                                .foregroundStyle(.green)
+                        }
+                    }
+                    Section {
+                        ForEach(scans) { scan in
+                            NavigationLink(destination: ArtifactScanDetailView(scan: scan)) {
+                                ScanResultRow(scan: scan)
+                            }
+                        }
                     }
                 }
                 .listStyle(.plain)
@@ -106,6 +129,20 @@ struct ArtifactScanResultsView: View {
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    Task { await triggerScan() }
+                } label: {
+                    if isScanning {
+                        ProgressView()
+                    } else {
+                        Label("Rescan", systemImage: "arrow.clockwise")
+                    }
+                }
+                .disabled(isScanning)
+            }
+        }
         .refreshable { await loadScans() }
         .task { await loadScans() }
     }
@@ -122,6 +159,18 @@ struct ArtifactScanResultsView: View {
         }
         isLoading = false
     }
+
+    private func triggerScan() async {
+        isScanning = true
+        defer { isScanning = false }
+        do {
+            let result = try await apiClient.triggerScan(artifactId: artifactId)
+            banner = result.message
+            await loadScans()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }
 
 // MARK: - Artifact Scan Detail
@@ -133,6 +182,8 @@ struct ArtifactScanDetailView: View {
     @State private var findings: [ScanFinding] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var actionError: String?
+    @State private var acknowledgingFinding: ScanFinding?
 
     private let apiClient = APIClient.shared
 
@@ -165,6 +216,23 @@ struct ArtifactScanDetailView: View {
                         Section("Findings (\(findings.count))") {
                             ForEach(findings) { finding in
                                 FindingRow(finding: finding)
+                                    .swipeActions(edge: .trailing) {
+                                        if finding.isAcknowledged {
+                                            Button {
+                                                Task { await revoke(finding) }
+                                            } label: {
+                                                Label("Revoke", systemImage: "arrow.uturn.backward")
+                                            }
+                                            .tint(.orange)
+                                        } else {
+                                            Button {
+                                                acknowledgingFinding = finding
+                                            } label: {
+                                                Label("Acknowledge", systemImage: "checkmark.circle")
+                                            }
+                                            .tint(.green)
+                                        }
+                                    }
                             }
                         }
                     }
@@ -178,6 +246,19 @@ struct ArtifactScanDetailView: View {
         #endif
         .refreshable { await loadFindings() }
         .task { await loadFindings() }
+        .sheet(item: $acknowledgingFinding) { finding in
+            AcknowledgeFindingSheet(finding: finding) { reason in
+                await acknowledge(finding, reason: reason)
+            }
+        }
+        .alert("Action Failed", isPresented: Binding(
+            get: { actionError != nil },
+            set: { if !$0 { actionError = nil } }
+        )) {
+            Button("OK", role: .cancel) { actionError = nil }
+        } message: {
+            Text(actionError ?? "")
+        }
     }
 
     private var scanTypeTitle: String {
@@ -253,6 +334,94 @@ struct ArtifactScanDetailView: View {
             }
         }
         isLoading = false
+    }
+
+    private func acknowledge(_ finding: ScanFinding, reason: String) async {
+        do {
+            let updated = try await apiClient.acknowledgeFinding(id: finding.id, reason: reason)
+            replace(updated)
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    private func revoke(_ finding: ScanFinding) async {
+        do {
+            let updated = try await apiClient.revokeFindingAcknowledgment(id: finding.id)
+            replace(updated)
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
+    /// Replace a finding in place so the row reflects the new acknowledgment state
+    /// without a full reload.
+    private func replace(_ updated: ScanFinding) {
+        if let index = findings.firstIndex(where: { $0.id == updated.id }) {
+            findings[index] = updated
+        }
+    }
+}
+
+// MARK: - Acknowledge Finding Sheet
+
+/// Prompts for an acknowledgment reason before acknowledging a finding.
+struct AcknowledgeFindingSheet: View {
+    let finding: ScanFinding
+    let onSubmit: (String) async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var reason = ""
+    @State private var isSubmitting = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text(finding.title)
+                        .font(.headline)
+                    if let cve = finding.cveId, !cve.isEmpty {
+                        Text(cve)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                    }
+                } header: {
+                    Text("Finding")
+                }
+
+                Section {
+                    TextField("Reason", text: $reason, axis: .vertical)
+                        .lineLimit(3...6)
+                } header: {
+                    Text("Acknowledgment Reason")
+                } footer: {
+                    Text("Explain why this finding is accepted (for example, false positive or mitigated).")
+                }
+            }
+            .navigationTitle("Acknowledge")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Acknowledge") {
+                        isSubmitting = true
+                        Task {
+                            await onSubmit(reason.trimmingCharacters(in: .whitespacesAndNewlines))
+                            isSubmitting = false
+                            dismiss()
+                        }
+                    }
+                    .disabled(reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting)
+                }
+            }
+        }
+        #if os(macOS)
+        .frame(minWidth: 380, minHeight: 280)
+        #endif
     }
 }
 

--- a/ArtifactKeeper/Sources/Features/Security/SecurityView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/SecurityView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct SecurityDashboardContentView: View {
+    @State private var dashboard: SecurityDashboard?
     @State private var scores: [RepoSecurityScore] = []
     @State private var repoNames: [String: String] = [:]
     @State private var isLoading = true
@@ -14,7 +15,7 @@ struct SecurityDashboardContentView: View {
         Group {
             if isLoading {
                 ProgressView("Loading security data...")
-            } else if scores.isEmpty && dtStatus?.enabled != true && cveTrends == nil {
+            } else if dashboard == nil && scores.isEmpty && dtStatus?.enabled != true && cveTrends == nil {
                 ContentUnavailableView(
                     "No Security Data",
                     systemImage: "shield.slash",
@@ -22,6 +23,12 @@ struct SecurityDashboardContentView: View {
                 )
             } else {
                 List {
+                    if let dashboard {
+                        Section {
+                            SecurityOverviewCard(dashboard: dashboard)
+                        }
+                    }
+
                     if let trends = cveTrends {
                         Section {
                             CveTrendsSummaryCard(trends: trends)
@@ -68,9 +75,17 @@ struct SecurityDashboardContentView: View {
     }
 
     private func loadData() async {
-        isLoading = scores.isEmpty && dtStatus == nil
+        isLoading = dashboard == nil && scores.isEmpty && dtStatus == nil
+
+        // Top-level overview counts. Independent so a failure hides only this card.
         do {
-            async let scoresResult: [RepoSecurityScore] = apiClient.request("/api/v1/security/scores")
+            dashboard = try await apiClient.getSecurityDashboard()
+        } catch {
+            // Dashboard not available — hide the overview card.
+        }
+
+        do {
+            async let scoresResult = apiClient.getSecurityScores()
             async let reposResult: RepositoryListResponse = apiClient.request("/api/v1/repositories?per_page=200")
 
             let (s, r) = try await (scoresResult, reposResult)
@@ -479,10 +494,72 @@ struct SecurityScoreRow: View {
 
             Spacer()
 
-            Text("Score: \(score.score)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("Score: \(score.score)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let acknowledged = score.acknowledgedCount, acknowledged > 0 {
+                    Text("\(acknowledged) ack'd")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
+    }
+}
+
+// MARK: - Security Overview Card
+
+/// Top-level security counts from the dashboard endpoint.
+struct SecurityOverviewCard: View {
+    let dashboard: SecurityDashboard
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "shield.lefthalf.filled")
+                    .font(.title3)
+                    .foregroundStyle(.blue)
+                Text("Security Overview")
+                    .font(.headline)
+            }
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                metric("Scans", "\(dashboard.totalScans)", color: .blue)
+                metric("Findings", "\(dashboard.totalFindings)", color: .secondary)
+                metric("Scanned Repos", "\(dashboard.reposWithScanning)", color: .blue)
+                metric("Critical", "\(dashboard.criticalFindings)", color: .red)
+                metric("High", "\(dashboard.highFindings)", color: .orange)
+                metric("Blocked", "\(dashboard.policyViolationsBlocked)", color: .purple)
+            }
+
+            HStack(spacing: 12) {
+                Label("\(dashboard.reposGradeA) grade A", systemImage: "checkmark.seal.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                Label("\(dashboard.reposGradeF) grade F", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func metric(_ label: String, _ value: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(color)
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+        .background(color.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
     }
 }
 

--- a/ArtifactKeeper/Tests/SecurityDispatchTests.swift
+++ b/ArtifactKeeper/Tests/SecurityDispatchTests.swift
@@ -49,7 +49,7 @@ final class RecordingTransport: ClientTransport, @unchecked Sendable {
         switch operationID {
         case "list_artifact_scans", "list_findings":
             return #"{"items":[],"total":0}"#
-        case "get_sbom_components":
+        case "get_sbom_components", "get_all_scores":
             return "[]"
         default:
             return "{}"
@@ -122,5 +122,64 @@ struct SecurityDispatchTests {
         #expect(rec?.method == "GET")
         #expect(pathComponent(rec?.path) == "/api/v1/sbom/sbom-3/components")
         #expect(rec?.operationID == "get_sbom_components")
+    }
+
+    // MARK: - Dashboard cluster
+
+    @Test func getSecurityDashboardHitsDashboardPath() async throws {
+        let (api, transport) = await makeClient()
+
+        // The canned body does not decode into DashboardResponse; the request is recorded
+        // before decode, so `try?` keeps the dispatch assertions meaningful.
+        _ = try? await api.getSecurityDashboard()
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/security/dashboard")
+        #expect(rec?.operationID == "get_dashboard")
+    }
+
+    @Test func getSecurityScoresHitsScoresPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try await api.getSecurityScores()
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/security/scores")
+        #expect(rec?.operationID == "get_all_scores")
+    }
+
+    @Test func acknowledgeFindingHitsAcknowledgePath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.acknowledgeFinding(id: "find-1", reason: "false positive")
+
+        let rec = transport.last
+        #expect(rec?.method == "POST")
+        #expect(pathComponent(rec?.path) == "/api/v1/security/findings/find-1/acknowledge")
+        #expect(rec?.operationID == "acknowledge_finding")
+    }
+
+    @Test func revokeAcknowledgmentHitsAcknowledgePath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.revokeFindingAcknowledgment(id: "find-2")
+
+        let rec = transport.last
+        #expect(rec?.method == "DELETE")
+        #expect(pathComponent(rec?.path) == "/api/v1/security/findings/find-2/acknowledge")
+        #expect(rec?.operationID == "revoke_acknowledgment")
+    }
+
+    @Test func triggerScanHitsScanPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.triggerScan(artifactId: "art-1")
+
+        let rec = transport.last
+        #expect(rec?.method == "POST")
+        #expect(pathComponent(rec?.path) == "/api/v1/security/scan")
+        #expect(rec?.operationID == "trigger_scan")
     }
 }

--- a/ArtifactKeeper/Tests/SecurityMappingTests.swift
+++ b/ArtifactKeeper/Tests/SecurityMappingTests.swift
@@ -237,4 +237,101 @@ struct SecurityMappingTests {
         #expect(model.generatorVersion == "1.0")
         #expect(model.generatedAt == Self.fixedIso)
     }
+
+    // MARK: - SecurityDashboard
+
+    @Test func securityDashboardMapsAllFields() {
+        let sdk = Components.Schemas.DashboardResponse(
+            critical_findings: 4,
+            high_findings: 9,
+            policy_violations_blocked: 2,
+            repos_grade_a: 5,
+            repos_grade_f: 1,
+            repos_with_scanning: 8,
+            total_findings: 30,
+            total_scans: 100
+        )
+
+        let model = SecurityDashboard(from: sdk)
+
+        #expect(model.criticalFindings == 4)
+        #expect(model.highFindings == 9)
+        #expect(model.policyViolationsBlocked == 2)
+        #expect(model.reposGradeA == 5)
+        #expect(model.reposGradeF == 1)
+        #expect(model.reposWithScanning == 8)
+        #expect(model.totalFindings == 30)
+        #expect(model.totalScans == 100)
+    }
+
+    // MARK: - RepoSecurityScore (from ScoreResponse)
+
+    @Test func securityScoreMapsAllFields() {
+        let sdk = Components.Schemas.ScoreResponse(
+            acknowledged_count: 3,
+            calculated_at: Self.fixedDate,
+            critical_count: 1,
+            grade: "B",
+            high_count: 2,
+            id: "score-1",
+            last_scan_at: Self.fixedDate,
+            low_count: 4,
+            medium_count: 5,
+            repository_id: "repo-1",
+            score: 82,
+            total_findings: 12
+        )
+
+        let model = RepoSecurityScore(from: sdk)
+
+        #expect(model.id == "score-1")
+        #expect(model.repositoryId == "repo-1")
+        #expect(model.grade == "B")
+        #expect(model.score == 82)
+        #expect(model.criticalCount == 1)
+        #expect(model.highCount == 2)
+        #expect(model.mediumCount == 5)
+        #expect(model.lowCount == 4)
+        #expect(model.totalFindings == 12)
+        #expect(model.acknowledgedCount == 3)
+        #expect(model.lastScanAt == Self.fixedIso)
+        #expect(model.calculatedAt == Self.fixedIso)
+    }
+
+    @Test func securityScoreMapsNilLastScan() {
+        let sdk = Components.Schemas.ScoreResponse(
+            acknowledged_count: 0,
+            calculated_at: Self.fixedDate,
+            critical_count: 0,
+            grade: "A",
+            high_count: 0,
+            id: "score-2",
+            last_scan_at: nil,
+            low_count: 0,
+            medium_count: 0,
+            repository_id: "repo-2",
+            score: 100,
+            total_findings: 0
+        )
+
+        let model = RepoSecurityScore(from: sdk)
+
+        #expect(model.lastScanAt == nil)
+        #expect(model.grade == "A")
+        #expect(model.score == 100)
+    }
+
+    // MARK: - TriggerScanResult
+
+    @Test func triggerScanResultMaps() {
+        let sdk = Components.Schemas.TriggerScanResponse(
+            artifacts_queued: 7,
+            message: "Queued 7 artifacts for scanning"
+        )
+
+        let model = TriggerScanResult(from: sdk)
+
+        #expect(model.artifactsQueued == 7)
+        #expect(model.message == "Queued 7 artifacts for scanning")
+    }
 }


### PR DESCRIPTION
## Summary

Wires the Security dashboard cluster to the v1.2.1 ArtifactKeeperClient. Wave B of the Security section work (#40), on top of wave A (#50, merged). Builds on the existing dashboard scaffolding in `SecurityView.swift` (`SecurityDashboardContentView`) rather than duplicating it.

Changes:
- Security overview card at the top of the dashboard from `get_dashboard` (scans, findings, scanned repos, critical/high, policy-violations-blocked, grade A/F)
- Repository scores refactored from a raw request to SDK `get_all_scores`; `RepoSecurityScore` extended backward-compatibly with `total_findings`, `acknowledged_count`, `last_scan_at`, `calculated_at` and the score row surfaces the acknowledged count
- Acknowledge / revoke findings on the artifact scan detail (`acknowledge_finding`, `revoke_acknowledgment`) via swipe actions + a reason-prompt sheet; the row updates in place
- Rescan from the artifact scan list (`trigger_scan`) via toolbar and empty-state buttons

### Operations covered (Section == Security)

| operationId | method + path | surface |
|-------------|---------------|---------|
| get_dashboard | GET /api/v1/security/dashboard | SecurityOverviewCard |
| get_all_scores | GET /api/v1/security/scores | SecurityDashboardContentView |
| acknowledge_finding | POST /api/v1/security/findings/{id}/acknowledge | AcknowledgeFindingSheet |
| revoke_acknowledgment | DELETE /api/v1/security/findings/{id}/acknowledge | swipe action |
| trigger_scan | POST /api/v1/security/scan | Rescan button |

SDK-backed `APIClient` methods route through the injectable SDK-client seam (added in #50) and map generated responses onto app models in `SecurityMapping.swift`.

Closes #53
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Tests (Swift Testing): mapping tests for `SecurityDashboard`, `RepoSecurityScore` (from `ScoreResponse`), `TriggerScanResult`; path-pinning dispatch tests for all five methods via the per-instance `RecordingTransport`, asserting request path, method and operationId. Full suite: 455 tests pass under parallel `swift test`. macOS build: SUCCEEDED.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [x] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements
- [ ] N/A - no UI changes