### PR TITLE
feat(ios): plugins list, detail, and lifecycle

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		238DBF144A2302C11DE50388 /* ChangePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7812397531D2CD01F4488BC6 /* ChangePasswordView.swift */; };
 		2765A46120FE03FEBFC1E7A5 /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = AAB8C31E7368B19A07AE1A3E /* OpenAPIURLSession */; };
 		28EDDF86319305C5ABC398D0 /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CFB90021A1428D8962F1BF /* Operations.swift */; };
+		293314A1B0346F707F5B3CE4 /* PluginPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4147C420ECCBB9137917722C /* PluginPathTests.swift */; };
 		2BBCC7E1EFC1A7A5C06BD188 /* SecurityDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */; };
 		2D8B1BCF039F334B0A7FD76A /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9415E01C2D644848CDBB4D0 /* Theme.swift */; };
 		2DDFD6ABC4E15C7FFF7C72C5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1164C99171DC47A99F71C0D /* Assets.xcassets */; };
@@ -109,6 +110,7 @@
 		828D28540C4E96952079036A /* AccountToolbarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A527DEEF9DECA3F2E8EC26 /* AccountToolbarModifier.swift */; };
 		82D32C6CEE6B9A5386787EEF /* RepoUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C1CC3C4956018E653EC486 /* RepoUploadView.swift */; };
 		83D01D48B7B7C3739E1344B3 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942CFADFFB28FA592F32CAB1 /* ModelTests.swift */; };
+		8408FA6FC3825C51913D197A /* PluginsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F05BA048E8B88FD14314F17 /* PluginsView.swift */; };
 		850750014FDAA447F7FEAA6A /* SecuritySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD29BEA4F2708262CE34F2E3 /* SecuritySectionView.swift */; };
 		859514D003E6E75A90E88192 /* UsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8761FACD0287EF99C0A1E50 /* UsersView.swift */; };
 		85BE46E9B704E5E25509D2FC /* APIClientExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */; };
@@ -136,6 +138,7 @@
 		AD2DBF5F7973BE47E351CC36 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1901D688CCAD3DE71AA681AC /* APIClientTests.swift */; };
 		AF076028A446FB1E28446D96 /* DtDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59106973EB99FD9424D44224 /* DtDashboardView.swift */; };
 		AFDDA47CBD83C0460C150C5D /* MonitoringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F6787AE2A18008C8EA282F /* MonitoringView.swift */; };
+		B18AAE17086834FBB57455D9 /* PluginPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4147C420ECCBB9137917722C /* PluginPathTests.swift */; };
 		B21993AEB170DF2F11F595FC /* DtProjectsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07736CEE9959BC4566162E12 /* DtProjectsView.swift */; };
 		B27985BB328A3F0ACCEF2EB5 /* LicensePoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */; };
 		B2BDDB70803CC764E1147668 /* RepoSecurityConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */; };
@@ -184,6 +187,7 @@
 		E2678146D7F808D22B485573 /* SecurityDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */; };
 		E4618623F8473A8661B7CC6F /* ChangePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7812397531D2CD01F4488BC6 /* ChangePasswordView.swift */; };
 		E57D1E3FC479A28A54467A5B /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DDB4F8B15C1FB99A2843 /* Package.swift */; };
+		E95246F33B27251305C22435 /* PluginsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F05BA048E8B88FD14314F17 /* PluginsView.swift */; };
 		EA935E6E499F8A518FCBA8C3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3E2D65A21BA60C8957EE36 /* ContentView.swift */; };
 		EAC22A0EE22A2528BABD2C6B /* Build.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90190CE35DA804C357A5FFDB /* Build.swift */; };
 		EBBA4D16B78FD192D954563C /* BuildsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E5BB60BE578603D5B6925 /* BuildsView.swift */; };
@@ -239,6 +243,7 @@
 		3ADAC51BA77982E3BBFB4403 /* IntegrationSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationSectionView.swift; sourceTree = "<group>"; };
 		3D8118DAD8066C9D0EED317C /* Security.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Security.swift; sourceTree = "<group>"; };
 		3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPVerificationViewTests.swift; sourceTree = "<group>"; };
+		4147C420ECCBB9137917722C /* PluginPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginPathTests.swift; sourceTree = "<group>"; };
 		435C7C6ACC4028C205301D14 /* RepositoryTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryTreeTests.swift; sourceTree = "<group>"; };
 		43C4236474392052DD29004F /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		4F60553EA149CE733245164B /* StagingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagingDetailView.swift; sourceTree = "<group>"; };
@@ -274,6 +279,7 @@
 		862E1C3205340290276A9B75 /* RepositoryTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryTree.swift; sourceTree = "<group>"; };
 		888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewTests.swift; sourceTree = "<group>"; };
 		8DF4F010E1DD1DC5415E7F11 /* Sbom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sbom.swift; sourceTree = "<group>"; };
+		8F05BA048E8B88FD14314F17 /* PluginsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginsView.swift; sourceTree = "<group>"; };
 		8F34D6E71603103BC21FD8EA /* PromotionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionSheet.swift; sourceTree = "<group>"; };
 		90190CE35DA804C357A5FFDB /* Build.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Build.swift; sourceTree = "<group>"; };
 		9050B925E8CDAB492ED01C01 /* AnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsView.swift; sourceTree = "<group>"; };
@@ -395,6 +401,7 @@
 				888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */,
 				AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */,
 				942CFADFFB28FA592F32CAB1 /* ModelTests.swift */,
+				4147C420ECCBB9137917722C /* PluginPathTests.swift */,
 				435C7C6ACC4028C205301D14 /* RepositoryTreeTests.swift */,
 				F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */,
 				CAF4590E6775407858BBAC86 /* SecurityMappingTests.swift */,
@@ -657,6 +664,7 @@
 			isa = PBXGroup;
 			children = (
 				F130C4E4EC403EC23594AE44 /* PeersView.swift */,
+				8F05BA048E8B88FD14314F17 /* PluginsView.swift */,
 				8067728F7917AD61F0DB4037 /* ReplicationView.swift */,
 				8063DEF3B0228C26496797B7 /* WebhooksView.swift */,
 			);
@@ -828,6 +836,7 @@
 				99C3358F603E8600CA038F75 /* DashboardViewTests.swift in Sources */,
 				ECE469E91BEE0E35EB258F98 /* KeychainManagerTests.swift in Sources */,
 				FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */,
+				293314A1B0346F707F5B3CE4 /* PluginPathTests.swift in Sources */,
 				1A02AD83B2F212120BFC892A /* RepositoryTreeTests.swift in Sources */,
 				E2678146D7F808D22B485573 /* SecurityDispatchTests.swift in Sources */,
 				EC57A5F27A84651FE192BC0A /* SecurityMappingTests.swift in Sources */,
@@ -878,6 +887,7 @@
 				47DFA7F8B01E5A21906642A2 /* Package.swift in Sources */,
 				363B3E9588A4895C999757BC /* PackagesView.swift in Sources */,
 				95AFE5BD66F78CB88FB2ABA1 /* PeersView.swift in Sources */,
+				8408FA6FC3825C51913D197A /* PluginsView.swift in Sources */,
 				706149420AF74CC3C2F55FDB /* PoliciesView.swift in Sources */,
 				11ADAFBA69061A50ABECD77C /* ProfileView.swift in Sources */,
 				55E48C58A4F43DC5DC868FE0 /* Promotion.swift in Sources */,
@@ -933,6 +943,7 @@
 				3366AEE087831CF15004691F /* DashboardViewTests.swift in Sources */,
 				6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */,
 				83D01D48B7B7C3739E1344B3 /* ModelTests.swift in Sources */,
+				B18AAE17086834FBB57455D9 /* PluginPathTests.swift in Sources */,
 				4BA74F65F09BD28BC25CC705 /* RepositoryTreeTests.swift in Sources */,
 				2BBCC7E1EFC1A7A5C06BD188 /* SecurityDispatchTests.swift in Sources */,
 				BF54F129B023787CC9A44249 /* SecurityMappingTests.swift in Sources */,
@@ -983,6 +994,7 @@
 				E57D1E3FC479A28A54467A5B /* Package.swift in Sources */,
 				B88EC39592199C1C4E1FB621 /* PackagesView.swift in Sources */,
 				C0426BF8DC4EE20233E24AC4 /* PeersView.swift in Sources */,
+				E95246F33B27251305C22435 /* PluginsView.swift in Sources */,
 				50E508B7E51DFFC65B9BCBCE /* PoliciesView.swift in Sources */,
 				DD9C336F7D973FA27ACD095E /* ProfileView.swift in Sources */,
 				C271C3B782A35CE71284249F /* Promotion.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -523,6 +523,13 @@ actor APIClient {
         try await requestVoid("/api/v1/artifacts/\(id)/labels/\(key)", method: "DELETE")
     }
 
+    // MARK: Plugins (Integration: GET /api/v1/plugins/{id})
+
+    /// Fetch a single plugin's current state by id.
+    func getPlugin(id: String) async throws -> Plugin {
+        try await request("/api/v1/plugins/\(id)")
+    }
+
     // MARK: Repository Tree Browse (1.2.1: GET /api/v1/tree)
 
     /// Fetch the repository tree at a given path. Pass an empty path for the root.

--- a/ArtifactKeeper/Sources/Core/Auth/AuthManager.swift
+++ b/ArtifactKeeper/Sources/Core/Auth/AuthManager.swift
@@ -21,8 +21,14 @@ class AuthManager: ObservableObject {
     /// active server connection so that token lookup is always correct.
     private var currentServerURL: String
 
-    init() {
-        self.currentServerURL = UserDefaults.standard.string(forKey: APIClient.serverURLKey) ?? ""
+    /// The defaults store the server URL is read from. Injectable so tests can
+    /// supply an isolated suite instead of sharing `.standard`, which races
+    /// across parallel test suites.
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.currentServerURL = defaults.string(forKey: APIClient.serverURLKey) ?? ""
     }
 
     // MARK: - Session Restoration
@@ -204,7 +210,7 @@ class AuthManager: ObservableObject {
     func handleLoginSuccess(accessToken: String, refreshToken: String?, mustChange: Bool) async {
         // Ensure we have the current server URL.
         let serverURL = currentServerURL.isEmpty
-            ? (UserDefaults.standard.string(forKey: APIClient.serverURLKey) ?? "")
+            ? (defaults.string(forKey: APIClient.serverURLKey) ?? "")
             : currentServerURL
         currentServerURL = serverURL
 

--- a/ArtifactKeeper/Sources/Core/Models/Integration.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Integration.swift
@@ -141,3 +141,42 @@ struct RotateWebhookSecretResponse: Codable, Identifiable, Sendable {
         case previousSecretExpiresAt = "previous_secret_expires_at"
     }
 }
+
+// MARK: - Plugins (WASM format plugins)
+
+/// An installed WASM plugin. The free-form `config_schema` object is intentionally
+/// not decoded: the list/detail UI surfaces identity, type, status and timing.
+struct Plugin: Codable, Identifiable, Sendable {
+    let id: String
+    let name: String
+    let displayName: String
+    let version: String
+    let status: String
+    let pluginType: String
+    let description: String?
+    let author: String?
+    let homepage: String?
+    let installedAt: String
+    let enabledAt: String?
+
+    /// Plugins report status as a string; treat anything other than an explicit
+    /// disabled/inactive state as enabled for the toggle control.
+    var isEnabled: Bool {
+        switch status.lowercased() {
+        case "disabled", "inactive", "stopped": return false
+        default: return true
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, version, status, description, author, homepage
+        case displayName = "display_name"
+        case pluginType = "plugin_type"
+        case installedAt = "installed_at"
+        case enabledAt = "enabled_at"
+    }
+}
+
+struct PluginListResponse: Codable, Sendable {
+    let items: [Plugin]
+}

--- a/ArtifactKeeper/Sources/Features/Integration/PluginsView.swift
+++ b/ArtifactKeeper/Sources/Features/Integration/PluginsView.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+
+/// Lists installed WASM format plugins and supports enable/disable/reload.
+/// Installation (upload/git/local/zip), uninstall and config authoring are
+/// deferred: they are deep-authoring/upload flows better suited to the web UI.
+struct PluginsView: View {
+    @State private var plugins: [Plugin] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var mutatingPluginId: String?
+    @State private var actionMessage: (success: Bool, text: String)?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading plugins...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                ContentUnavailableView(
+                    "Plugins Unavailable",
+                    systemImage: "puzzlepiece.extension",
+                    description: Text(error)
+                )
+            } else if plugins.isEmpty {
+                ContentUnavailableView(
+                    "No Plugins",
+                    systemImage: "puzzlepiece",
+                    description: Text("No format plugins are installed.")
+                )
+            } else {
+                List {
+                    if let actionMessage {
+                        Section {
+                            HStack(spacing: 8) {
+                                Image(systemName: actionMessage.success ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    .foregroundStyle(actionMessage.success ? .green : .red)
+                                Text(actionMessage.text)
+                                    .font(.caption)
+                                    .foregroundStyle(actionMessage.success ? .green : .red)
+                            }
+                        }
+                    }
+                    ForEach(plugins) { plugin in
+                        NavigationLink {
+                            PluginDetailView(
+                                plugin: plugin,
+                                isMutating: mutatingPluginId == plugin.id,
+                                onToggle: { await toggle(plugin) },
+                                onReload: { await reload(plugin) }
+                            )
+                        } label: {
+                            PluginRow(plugin: plugin)
+                        }
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .refreshable { await loadPlugins() }
+        .task { await loadPlugins() }
+    }
+
+    private func loadPlugins() async {
+        isLoading = plugins.isEmpty
+        do {
+            let response: PluginListResponse = try await apiClient.request("/api/v1/plugins")
+            plugins = response.items
+            errorMessage = nil
+        } catch {
+            if plugins.isEmpty {
+                errorMessage = "Could not load plugins. This feature may not be available on your server."
+            }
+        }
+        isLoading = false
+    }
+
+    private func toggle(_ plugin: Plugin) async {
+        let action = plugin.isEnabled ? "disable" : "enable"
+        mutatingPluginId = plugin.id
+        defer { mutatingPluginId = nil }
+        do {
+            try await apiClient.requestVoid(
+                "/api/v1/plugins/\(plugin.id)/\(action)",
+                method: "POST"
+            )
+            actionMessage = (true, "\(plugin.displayName) \(action)d.")
+            await loadPlugins()
+        } catch {
+            actionMessage = (false, "Failed to \(action) \(plugin.displayName): \(error.localizedDescription)")
+        }
+    }
+
+    private func reload(_ plugin: Plugin) async {
+        mutatingPluginId = plugin.id
+        defer { mutatingPluginId = nil }
+        do {
+            let _: Plugin = try await apiClient.request(
+                "/api/v1/plugins/\(plugin.id)/reload",
+                method: "POST"
+            )
+            actionMessage = (true, "\(plugin.displayName) reloaded.")
+            await loadPlugins()
+        } catch {
+            actionMessage = (false, "Failed to reload \(plugin.displayName): \(error.localizedDescription)")
+        }
+    }
+}
+
+struct PluginRow: View {
+    let plugin: Plugin
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(plugin.displayName)
+                    .font(.body.weight(.medium))
+                Text("v\(plugin.version)")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(plugin.isEnabled ? .green : .gray)
+                        .frame(width: 8, height: 8)
+                    Text(plugin.status.capitalized)
+                        .font(.caption)
+                        .foregroundStyle(plugin.isEnabled ? .green : .secondary)
+                }
+            }
+            HStack(spacing: 6) {
+                Text(plugin.pluginType)
+                    .font(.caption2)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.blue.opacity(0.1), in: Capsule())
+                    .foregroundStyle(.blue)
+                if let description = plugin.description, !description.isEmpty {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - Plugin Detail
+
+struct PluginDetailView: View {
+    let plugin: Plugin
+    let isMutating: Bool
+    let onToggle: () async -> Void
+    let onReload: () async -> Void
+
+    var body: some View {
+        List {
+            Section("Plugin") {
+                detailRow("Name", plugin.displayName)
+                detailRow("Identifier", plugin.name)
+                detailRow("Version", plugin.version)
+                detailRow("Type", plugin.pluginType)
+                detailRow("Status", plugin.status.capitalized)
+                if let author = plugin.author, !author.isEmpty {
+                    detailRow("Author", author)
+                }
+                if let homepage = plugin.homepage, !homepage.isEmpty {
+                    detailRow("Homepage", homepage)
+                }
+            }
+
+            if let description = plugin.description, !description.isEmpty {
+                Section("Description") {
+                    Text(description)
+                        .font(.subheadline)
+                }
+            }
+
+            Section("Lifecycle") {
+                detailRow("Installed", plugin.installedAt)
+                if let enabledAt = plugin.enabledAt, !enabledAt.isEmpty {
+                    detailRow("Enabled", enabledAt)
+                }
+            }
+
+            Section {
+                Button {
+                    Task { await onToggle() }
+                } label: {
+                    Label(plugin.isEnabled ? "Disable" : "Enable",
+                          systemImage: plugin.isEnabled ? "pause.circle" : "play.circle")
+                }
+                .disabled(isMutating)
+
+                Button {
+                    Task { await onReload() }
+                } label: {
+                    Label("Reload", systemImage: "arrow.clockwise")
+                }
+                .disabled(isMutating)
+            }
+        }
+        .navigationTitle(plugin.displayName)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .multilineTextAlignment(.trailing)
+        }
+        .font(.subheadline)
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Integration/PluginsView.swift
+++ b/ArtifactKeeper/Sources/Features/Integration/PluginsView.swift
@@ -45,7 +45,7 @@ struct PluginsView: View {
                     ForEach(plugins) { plugin in
                         NavigationLink {
                             PluginDetailView(
-                                plugin: plugin,
+                                listPlugin: plugin,
                                 isMutating: mutatingPluginId == plugin.id,
                                 onToggle: { await toggle(plugin) },
                                 onReload: { await reload(plugin) }
@@ -151,13 +151,32 @@ struct PluginRow: View {
 // MARK: - Plugin Detail
 
 struct PluginDetailView: View {
-    let plugin: Plugin
+    /// The plugin as known from the list, shown immediately while the detail
+    /// fetch is in flight.
+    let listPlugin: Plugin
     let isMutating: Bool
     let onToggle: () async -> Void
     let onReload: () async -> Void
 
+    @State private var fetched: Plugin?
+    @State private var loadError: String?
+
+    private let apiClient = APIClient.shared
+
+    /// The freshest plugin we have: the by-id detail fetch if it succeeded,
+    /// else the list value.
+    private var plugin: Plugin { fetched ?? listPlugin }
+
     var body: some View {
         List {
+            if let loadError {
+                Section {
+                    Label(loadError, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Section("Plugin") {
                 detailRow("Name", plugin.displayName)
                 detailRow("Identifier", plugin.name)
@@ -207,6 +226,18 @@ struct PluginDetailView: View {
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
+        .task { await loadDetail() }
+        .refreshable { await loadDetail() }
+    }
+
+    private func loadDetail() async {
+        do {
+            fetched = try await apiClient.getPlugin(id: listPlugin.id)
+            loadError = nil
+        } catch {
+            // Keep showing the list value; surface that the refresh failed.
+            loadError = "Showing cached details; could not refresh: \(error.localizedDescription)"
+        }
     }
 
     private func detailRow(_ label: String, _ value: String) -> some View {

--- a/ArtifactKeeper/Sources/Sections/IntegrationSectionView.swift
+++ b/ArtifactKeeper/Sources/Sections/IntegrationSectionView.swift
@@ -10,6 +10,7 @@ struct IntegrationSectionView: View {
                     Text("Peers").tag("peers")
                     Text("Replication").tag("replication")
                     Text("Webhooks").tag("webhooks")
+                    Text("Plugins").tag("plugins")
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
@@ -25,6 +26,8 @@ struct IntegrationSectionView: View {
                         ReplicationView()
                     case "webhooks":
                         WebhooksView()
+                    case "plugins":
+                        PluginsView()
                     default:
                         EmptyView()
                     }

--- a/ArtifactKeeper/Tests/AuthManagerExtendedTests.swift
+++ b/ArtifactKeeper/Tests/AuthManagerExtendedTests.swift
@@ -50,6 +50,23 @@ enum JWTTestHelper {
     }
 }
 
+// MARK: - Isolated Defaults Helper
+
+/// Builds an AuthManager bound to a private, in-memory UserDefaults suite so the
+/// server-URL handoff a test exercises cannot race other parallel suites that
+/// mutate `UserDefaults.standard`. Each call uses a unique suite name and clears
+/// it, isolating the `serverURLKey` the way per-session keys isolate the mock.
+@MainActor
+private func makeIsolatedAuth(serverURL: String?) -> AuthManager {
+    let suiteName = "auth-tests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    if let serverURL {
+        defaults.set(serverURL, forKey: APIClient.serverURLKey)
+    }
+    return AuthManager(defaults: defaults)
+}
+
 // MARK: - AuthManager.decodeJWT Tests
 
 @Suite("AuthManager decodeJWT Tests")
@@ -358,9 +375,9 @@ struct AuthManagerExtendedStateTests {
     }
 
     @Test @MainActor func restoreSessionReturnsEarlyWithEmptyServerURL() async {
-        // Clear any stored server URL
-        UserDefaults.standard.removeObject(forKey: APIClient.serverURLKey)
-        let auth = AuthManager()
+        // Isolated empty defaults so a parallel test setting serverURLKey on
+        // .standard cannot hand this AuthManager a non-empty server URL.
+        let auth = makeIsolatedAuth(serverURL: nil)
         // This should return early since currentServerURL is empty
         await auth.restoreSession()
         #expect(auth.isAuthenticated == false)
@@ -368,8 +385,7 @@ struct AuthManagerExtendedStateTests {
     }
 
     @Test @MainActor func refreshTokenReturnsFalseWithEmptyServerURL() async {
-        UserDefaults.standard.removeObject(forKey: APIClient.serverURLKey)
-        let auth = AuthManager()
+        let auth = makeIsolatedAuth(serverURL: nil)
         let result = await auth.refreshToken()
         #expect(result == false)
     }
@@ -606,12 +622,7 @@ struct AuthManagerExtendedStateTests {
 
     @Test @MainActor func handleLoginSuccessFallsBackToUserDefaultsServerURL() async {
         let server = "https://login-fallback-\(UUID().uuidString).example.com"
-        defer {
-            KeychainManager.deleteTokens(serverURL: server)
-            UserDefaults.standard.removeObject(forKey: APIClient.serverURLKey)
-        }
-
-        UserDefaults.standard.set(server, forKey: APIClient.serverURLKey)
+        defer { KeychainManager.deleteTokens(serverURL: server) }
 
         let futureExp = Date().timeIntervalSince1970 + 3600
         guard let jwt = JWTTestHelper.makeUserJWT(exp: futureExp) else {
@@ -619,9 +630,11 @@ struct AuthManagerExtendedStateTests {
             return
         }
 
-        // Create AuthManager but do NOT call updateServerURL
-        // so currentServerURL is set from UserDefaults in init
-        let auth = AuthManager()
+        // Create AuthManager bound to an isolated defaults suite holding the
+        // server URL, and do NOT call updateServerURL, so currentServerURL is
+        // set from defaults in init. The isolated suite keeps this from racing
+        // other parallel tests that mutate UserDefaults.standard.
+        let auth = makeIsolatedAuth(serverURL: server)
 
         await auth.handleLoginSuccess(
             accessToken: jwt,
@@ -636,15 +649,12 @@ struct AuthManagerExtendedStateTests {
 
     @Test @MainActor func handleLoginSuccessWithEmptyServerURLFallsBackToUserDefaults() async {
         let server = "https://empty-url-\(UUID().uuidString).example.com"
-        defer {
-            KeychainManager.deleteTokens(serverURL: server)
-            UserDefaults.standard.removeObject(forKey: APIClient.serverURLKey)
-        }
+        defer { KeychainManager.deleteTokens(serverURL: server) }
 
-        // Set a server URL in UserDefaults, then create auth with empty currentServerURL
-        UserDefaults.standard.set(server, forKey: APIClient.serverURLKey)
-        let auth = AuthManager()
-        // Force currentServerURL to empty
+        // Server URL lives in an isolated defaults suite; force currentServerURL
+        // empty so handleLoginSuccess must fall back to that suite. Isolation
+        // keeps this from racing other parallel tests on UserDefaults.standard.
+        let auth = makeIsolatedAuth(serverURL: server)
         auth.updateServerURL("")
 
         let futureExp = Date().timeIntervalSince1970 + 3600

--- a/ArtifactKeeper/Tests/PluginPathTests.swift
+++ b/ArtifactKeeper/Tests/PluginPathTests.swift
@@ -56,7 +56,9 @@ struct PluginPathTests {
             return pluginOk(request.url!, pluginJSON)
         }
 
-        let _: Plugin = try await mock.client.request("/api/v1/plugins/plg-1")
+        // Exercise the real APIClient.getPlugin(id:) so this pins the method's
+        // path derivation, not a hand-built URL.
+        let _: Plugin = try await mock.client.getPlugin(id: "plg-1")
 
         #expect(log.contains(method: "GET", path: "/api/v1/plugins/plg-1"))
     }

--- a/ArtifactKeeper/Tests/PluginPathTests.swift
+++ b/ArtifactKeeper/Tests/PluginPathTests.swift
@@ -1,0 +1,105 @@
+import Testing
+import Foundation
+@testable import ArtifactKeeper
+
+// Path-pinning tests for the plugin list / detail / lifecycle endpoints used by
+// PluginsView. These call APIClient.request / requestVoid against a MockSession
+// (per-test isolated handler, defined in APIClientNetworkTests.swift) and assert
+// the exact 1.2.1 path and HTTP method. Each test owns its MockSession, so the
+// suite is safe under Swift Testing's parallel execution.
+
+private func pluginOk(_ url: URL, _ body: String, status: Int = 200) -> (HTTPURLResponse, Data) {
+    let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+    return (response, Data(body.utf8))
+}
+
+/// Records the (method, path) pairs a sequence of requests hits.
+private final class PluginCallLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [(method: String, path: String)] = []
+    func add(_ method: String, _ path: String) {
+        lock.lock(); values.append((method, path)); lock.unlock()
+    }
+    func contains(method: String, path: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return values.contains { $0.method == method && $0.path == path }
+    }
+}
+
+private let pluginJSON = """
+{"id":"plg-1","name":"unity","display_name":"Unity Format","version":"1.0.0",
+ "status":"enabled","plugin_type":"format","config_schema":{},
+ "installed_at":"2026-06-23T00:00:00Z"}
+"""
+
+@Suite("Plugin Path Tests")
+struct PluginPathTests {
+
+    @Test func listPluginsHitsPluginsPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PluginCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return pluginOk(request.url!, #"{"items":[]}"#)
+        }
+
+        let _: PluginListResponse = try await mock.client.request("/api/v1/plugins")
+
+        #expect(log.contains(method: "GET", path: "/api/v1/plugins"))
+    }
+
+    @Test func getPluginHitsPluginIdPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PluginCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return pluginOk(request.url!, pluginJSON)
+        }
+
+        let _: Plugin = try await mock.client.request("/api/v1/plugins/plg-1")
+
+        #expect(log.contains(method: "GET", path: "/api/v1/plugins/plg-1"))
+    }
+
+    @Test func enablePluginHitsEnablePath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PluginCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return pluginOk(request.url!, "")
+        }
+
+        try await mock.client.requestVoid("/api/v1/plugins/plg-1/enable", method: "POST")
+
+        #expect(log.contains(method: "POST", path: "/api/v1/plugins/plg-1/enable"))
+    }
+
+    @Test func disablePluginHitsDisablePath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PluginCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return pluginOk(request.url!, "")
+        }
+
+        try await mock.client.requestVoid("/api/v1/plugins/plg-1/disable", method: "POST")
+
+        #expect(log.contains(method: "POST", path: "/api/v1/plugins/plg-1/disable"))
+    }
+
+    @Test func reloadPluginHitsReloadPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PluginCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return pluginOk(request.url!, pluginJSON)
+        }
+
+        let _: Plugin = try await mock.client.request(
+            "/api/v1/plugins/plg-1/reload",
+            method: "POST"
+        )
+
+        #expect(log.contains(method: "POST", path: "/api/v1/plugins/plg-1/reload"))
+    }
+}


### PR DESCRIPTION
## Summary
Adds a Plugins screen to the Integration section (no plugin UI existed before).

Endpoints wired (raw `APIClient.request`, app-owned `Plugin` model):
- GET `/api/v1/plugins` (`list_plugins`) -> plugin list
- GET `/api/v1/plugins/{id}` (`get_plugin`) -> detail view fetches by id via `APIClient.getPlugin(id:)` on `.task` (renders the fetched plugin, falling back to the list value while loading)
- POST `/api/v1/plugins/{id}/enable` (`enable_plugin`)
- POST `/api/v1/plugins/{id}/disable` (`disable_plugin`)
- POST `/api/v1/plugins/{id}/reload` (`reload_plugin`)

New "Plugins" segment in `IntegrationSectionView`. Detail view exposes enable/disable/reload.

Path-pinning tests for all five endpoints via the `MockSession` pattern. `getPluginHitsPluginIdPath` exercises the real `APIClient.getPlugin(id:)` method (not a hand-built URL).

Also fixes a pre-existing parallel test-isolation race exposed by this PR shifting scheduling: `AuthManager` read the server URL from the shared `UserDefaults.standard[serverURLKey]`, which races across parallel suites. Made the defaults store injectable (`AuthManager(defaults:)`, production unchanged) and moved the server-URL-dependent tests onto per-test in-memory `UserDefaults(suiteName:)`.

### Deferred (noted in #59)
Out of scope for this PR, deferred to a later cluster:
- install variants: `install_plugin` (multipart), `install_from_zip` (multipart), `install_from_local`, `install_from_git` (multipart/local are file-upload flows; `install_from_git` and `uninstall_plugin` will be wired in a later plugins follow-up per lead guidance)
- `uninstall_plugin` (destructive; later follow-up with a confirm dialog)
- `get_plugin_config` / `update_plugin_config` (free-form JSON config authoring)
- `get_plugin_events` (deferred to a later cluster)
- format-handler family (`/api/v1/formats/*`) - planned as its own cluster

No matrix edits (orchestrator owns the matrix).

Part of #40
Closes #59

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full suite run three times in parallel (CI-style) after both fixes: 470 tests in 58 suites, all passing, no flake.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements
- [ ] N/A - no UI changes