### PR TITLE
feat(ios): security scan configurations list (list_scan_configs)

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		189014CE0807785BF1C97AF6 /* APIClientNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */; };
 		1A02AD83B2F212120BFC892A /* RepositoryTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435C7C6ACC4028C205301D14 /* RepositoryTreeTests.swift */; };
 		1AB249F434755BECF4124CA8 /* SetupInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113DC09E3B0845FAD9BDA8F6 /* SetupInstructionsView.swift */; };
+		1CC2147E6995CB8C42B11A2A /* ScanConfigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */; };
 		1EB081D63A5092425E75A0B0 /* RepositoryDetailTabbedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FEF3A0FA55ECC63DDC8899F /* RepositoryDetailTabbedView.swift */; };
 		2052B7B0961EC927404CD8F1 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8267620B852D7914EAD83DAE /* SettingsView.swift */; };
 		21792E2823728B81B6E3E621 /* RepositoryTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517D78FD253D2202880EF013 /* RepositoryTreeView.swift */; };
@@ -133,6 +134,7 @@
 		9F313A124D557820A4F7F737 /* RepoSecurityConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */; };
 		9FBBA3D5EAF49575952C78AD /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = F35A063FFE69F8B8A3CD7AEE /* OpenAPIURLSession */; };
 		A1A538DE905D6AF031923CF5 /* AuthManagerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */; };
+		A563ADC6B11F45AB50692ABA /* ScanConfigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */; };
 		A6FE919357227C480B8571C0 /* RepositoryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862E1C3205340290276A9B75 /* RepositoryTree.swift */; };
 		ABC754B5DC49717B25A912DB /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59705D3B5F2000ACABB8A48 /* Auth.swift */; };
 		AD2DBF5F7973BE47E351CC36 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1901D688CCAD3DE71AA681AC /* APIClientTests.swift */; };
@@ -294,6 +296,7 @@
 		AACFAEE53DF20945E710A82E /* SbomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SbomView.swift; sourceTree = "<group>"; };
 		AC7BD8467BED7C0A6ECE6DBE /* SecurityMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityMapping.swift; sourceTree = "<group>"; };
 		ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSecurityConfig.swift; sourceTree = "<group>"; };
+		AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanConfigsView.swift; sourceTree = "<group>"; };
 		B1164C99171DC47A99F71C0D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B6F9DDB4F8B15C1FB99A2843 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		BD2E5BB60BE578603D5B6925 /* BuildsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildsView.swift; sourceTree = "<group>"; };
@@ -434,6 +437,7 @@
 				5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */,
 				387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */,
 				AACFAEE53DF20945E710A82E /* SbomView.swift */,
+				AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */,
 				7351368D8EDB157E264ECBBC /* SecurityView.swift */,
 			);
 			path = Security;
@@ -906,6 +910,7 @@
 				D3653822D6C8332BC92D8642 /* SSOView.swift in Sources */,
 				B6A7958608DE308DD63F5435 /* Sbom.swift in Sources */,
 				7795B1C86E7E5530C0ECA6BE /* SbomView.swift in Sources */,
+				1CC2147E6995CB8C42B11A2A /* ScanConfigsView.swift in Sources */,
 				3D57CDAFE896BFB0BB441D87 /* SearchView.swift in Sources */,
 				0FAD280684B34F3ABB6306F5 /* Security.swift in Sources */,
 				EBCF23D7CB615A3242793594 /* SecurityMapping.swift in Sources */,
@@ -1013,6 +1018,7 @@
 				99FEE2AAD62A0388A67BF3C6 /* SSOView.swift in Sources */,
 				596F4AA252F5DB25B76106B8 /* Sbom.swift in Sources */,
 				B85DD5AD52ECDF8AF03AD72F /* SbomView.swift in Sources */,
+				A563ADC6B11F45AB50692ABA /* ScanConfigsView.swift in Sources */,
 				098B007AFDBBB928C7FC45AB /* SearchView.swift in Sources */,
 				8F03693614D04D4C4BE9C332 /* Security.swift in Sources */,
 				1710D4535FE4A32357750C7D /* SecurityMapping.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -769,6 +769,14 @@ actor APIClient {
         return TriggerScanResult(from: data)
     }
 
+    /// List per-repository scan configurations (GET /api/v1/security/configs).
+    func listScanConfigs() async throws -> [ScanConfig] {
+        let client = await sdkClientInstance()
+        let response = try await client.list_scan_configs()
+        let data = try response.ok.body.json
+        return data.map { ScanConfig(from: $0) }
+    }
+
     // MARK: SBOM (SDK-backed)
 
     /// Fetch the SBOM summary for an artifact (GET /api/v1/sbom/by-artifact/{artifact_id}).

--- a/ArtifactKeeper/Sources/Core/API/SecurityMapping.swift
+++ b/ArtifactKeeper/Sources/Core/API/SecurityMapping.swift
@@ -160,6 +160,22 @@ extension TriggerScanResult {
     }
 }
 
+extension ScanConfig {
+    init(from sdk: Components.Schemas.ScanConfigResponse) {
+        self.init(
+            id: sdk.id,
+            repositoryId: sdk.repository_id,
+            scanEnabled: sdk.scan_enabled,
+            scanOnUpload: sdk.scan_on_upload,
+            scanOnProxy: sdk.scan_on_proxy,
+            blockOnPolicyViolation: sdk.block_on_policy_violation,
+            severityThreshold: sdk.severity_threshold,
+            createdAt: SecurityMapping.isoString(sdk.created_at),
+            updatedAt: SecurityMapping.isoString(sdk.updated_at)
+        )
+    }
+}
+
 // MARK: - Date Formatting
 
 enum SecurityMapping {

--- a/ArtifactKeeper/Sources/Core/Models/Security.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Security.swift
@@ -175,3 +175,30 @@ struct TriggerScanResult: Sendable, Equatable {
     let artifactsQueued: Int
     let message: String
 }
+
+// MARK: - Scan Configuration (1.2.1 ScanConfigResponse)
+
+/// Per-repository scan configuration returned by `GET /api/v1/security/configs`.
+struct ScanConfig: Codable, Identifiable, Sendable, Equatable {
+    let id: String
+    let repositoryId: String
+    let scanEnabled: Bool
+    let scanOnUpload: Bool
+    let scanOnProxy: Bool
+    let blockOnPolicyViolation: Bool
+    let severityThreshold: String
+    let createdAt: String
+    let updatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case repositoryId = "repository_id"
+        case scanEnabled = "scan_enabled"
+        case scanOnUpload = "scan_on_upload"
+        case scanOnProxy = "scan_on_proxy"
+        case blockOnPolicyViolation = "block_on_policy_violation"
+        case severityThreshold = "severity_threshold"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Security/ScanConfigsView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/ScanConfigsView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+/// Read-only listing of per-repository scan configurations
+/// (GET /api/v1/security/configs). The configs are authored per repository
+/// from the repository detail Security tab; this view surfaces them all in one
+/// place so an operator can audit which repositories have scanning enabled and
+/// how their thresholds are set.
+struct ScanConfigsView: View {
+    @State private var configs: [ScanConfig] = []
+    @State private var repoNames: [String: String] = [:]
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading scan configurations\u{2026}")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                ContentUnavailableView {
+                    Label("Configurations Unavailable", systemImage: "gearshape.2")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Retry") { Task { await load() } }
+                        .buttonStyle(.borderedProminent)
+                }
+            } else if configs.isEmpty {
+                ContentUnavailableView(
+                    "No Scan Configurations",
+                    systemImage: "gearshape.2",
+                    description: Text("No repository has a scan configuration yet. Enable scanning from a repository's Security tab.")
+                )
+            } else {
+                List {
+                    ForEach(configs) { config in
+                        ScanConfigRow(
+                            config: config,
+                            repositoryName: repoNames[config.repositoryId]
+                        )
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .refreshable { await load() }
+        .task { await load() }
+    }
+
+    private func load() async {
+        isLoading = configs.isEmpty
+        do {
+            // Resolve repository ids to names in parallel so the rows can show a
+            // human-readable label instead of a bare UUID.
+            async let configsResult = apiClient.listScanConfigs()
+            async let reposResult = apiClient.listRepositories()
+            let loaded = try await configsResult
+            let repos = (try? await reposResult) ?? []
+
+            configs = loaded.sorted { lhs, rhs in
+                let l = repoNames[lhs.repositoryId] ?? lhs.repositoryId
+                let r = repoNames[rhs.repositoryId] ?? rhs.repositoryId
+                return l.localizedCaseInsensitiveCompare(r) == .orderedAscending
+            }
+            repoNames = Dictionary(uniqueKeysWithValues: repos.map { ($0.id, $0.name) })
+            errorMessage = nil
+        } catch {
+            if configs.isEmpty {
+                errorMessage = "Could not load scan configurations. You may need admin privileges."
+            }
+        }
+        isLoading = false
+    }
+}
+
+private struct ScanConfigRow: View {
+    let config: ScanConfig
+    let repositoryName: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: config.scanEnabled ? "checkmark.shield.fill" : "shield.slash")
+                    .foregroundStyle(config.scanEnabled ? Color.green : Color.secondary)
+                Text(repositoryName ?? config.repositoryId)
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+                Text(config.scanEnabled ? "Enabled" : "Disabled")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(config.scanEnabled ? Color.green : Color.secondary)
+            }
+
+            HStack(spacing: 8) {
+                if config.scanOnUpload {
+                    ScanConfigTag(text: "On Upload", systemImage: "arrow.up.doc")
+                }
+                if config.scanOnProxy {
+                    ScanConfigTag(text: "On Proxy", systemImage: "arrow.down.circle")
+                }
+                if config.blockOnPolicyViolation {
+                    ScanConfigTag(text: "Blocks Violations", systemImage: "hand.raised")
+                }
+            }
+
+            HStack {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(severityColor)
+                Text("Threshold: \(config.severityThreshold.capitalized)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var severityColor: Color {
+        switch config.severityThreshold.lowercased() {
+        case "critical": return .red
+        case "high": return .orange
+        case "medium": return .yellow
+        case "low": return .blue
+        default: return .secondary
+        }
+    }
+}
+
+private struct ScanConfigTag: View {
+    let text: String
+    let systemImage: String
+
+    var body: some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.accentColor.opacity(0.12))
+            .clipShape(Capsule())
+    }
+}

--- a/ArtifactKeeper/Sources/Sections/SecuritySectionView.swift
+++ b/ArtifactKeeper/Sources/Sections/SecuritySectionView.swift
@@ -8,7 +8,7 @@ struct SecuritySectionView: View {
             VStack(spacing: 0) {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 0) {
-                        ForEach(["dashboard", "scans", "policies", "licenses"], id: \.self) { tab in
+                        ForEach(["dashboard", "scans", "configs", "policies", "licenses"], id: \.self) { tab in
                             Button {
                                 selectedTab = tab
                             } label: {
@@ -35,6 +35,8 @@ struct SecuritySectionView: View {
                         SecurityDashboardContentView()
                     case "scans":
                         SecurityScansContentView()
+                    case "configs":
+                        ScanConfigsView()
                     case "policies":
                         PoliciesView()
                     case "licenses":
@@ -54,6 +56,7 @@ struct SecuritySectionView: View {
         switch tab {
         case "dashboard": return "Dashboard"
         case "scans": return "Scans"
+        case "configs": return "Configs"
         case "policies": return "Policies"
         case "licenses": return "Licenses"
         default: return tab.capitalized

--- a/ArtifactKeeper/Tests/SecurityDispatchTests.swift
+++ b/ArtifactKeeper/Tests/SecurityDispatchTests.swift
@@ -49,7 +49,7 @@ final class RecordingTransport: ClientTransport, @unchecked Sendable {
         switch operationID {
         case "list_artifact_scans", "list_findings":
             return #"{"items":[],"total":0}"#
-        case "get_sbom_components", "get_all_scores":
+        case "get_sbom_components", "get_all_scores", "list_scan_configs":
             return "[]"
         default:
             return "{}"
@@ -181,5 +181,16 @@ struct SecurityDispatchTests {
         #expect(rec?.method == "POST")
         #expect(pathComponent(rec?.path) == "/api/v1/security/scan")
         #expect(rec?.operationID == "trigger_scan")
+    }
+
+    @Test func listScanConfigsHitsConfigsPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try await api.listScanConfigs()
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/security/configs")
+        #expect(rec?.operationID == "list_scan_configs")
     }
 }

--- a/ArtifactKeeper/Tests/SecurityMappingTests.swift
+++ b/ArtifactKeeper/Tests/SecurityMappingTests.swift
@@ -334,4 +334,34 @@ struct SecurityMappingTests {
         #expect(model.artifactsQueued == 7)
         #expect(model.message == "Queued 7 artifacts for scanning")
     }
+
+    // MARK: - ScanConfig
+
+    @Test func scanConfigMaps() {
+        let created = Date(timeIntervalSince1970: 1_700_000_000)
+        let updated = Date(timeIntervalSince1970: 1_700_086_400)
+        let sdk = Components.Schemas.ScanConfigResponse(
+            block_on_policy_violation: true,
+            created_at: created,
+            id: "cfg-1",
+            repository_id: "repo-9",
+            scan_enabled: true,
+            scan_on_proxy: false,
+            scan_on_upload: true,
+            severity_threshold: "high",
+            updated_at: updated
+        )
+
+        let model = ScanConfig(from: sdk)
+
+        #expect(model.id == "cfg-1")
+        #expect(model.repositoryId == "repo-9")
+        #expect(model.scanEnabled)
+        #expect(model.scanOnUpload)
+        #expect(!model.scanOnProxy)
+        #expect(model.blockOnPolicyViolation)
+        #expect(model.severityThreshold == "high")
+        #expect(model.createdAt == SecurityMapping.isoString(created))
+        #expect(model.updatedAt == SecurityMapping.isoString(updated))
+    }
 }


### PR DESCRIPTION
## Summary
Adds a read-only **Configs** tab to the Security section that lists per-repository scan configurations from `GET /api/v1/security/configs` (`list_scan_configs`).

Each row shows:
- Repository name (resolved from the repository list; falls back to the UUID)
- Whether scanning is enabled (icon + label)
- Scan-on-upload / scan-on-proxy / block-on-violation flags as capsule tags
- Severity threshold, colored by level

Implementation follows the existing SDK-backed Security style:
- `ScanConfig` model in `Core/Models/Security.swift`
- `ScanConfig(from: Components.Schemas.ScanConfigResponse)` mapping in `SecurityMapping.swift`
- `APIClient.listScanConfigs()` dispatching the generated `list_scan_configs` operation
- `ScanConfigsView` with loading / error-with-retry / empty states, refreshable, Dynamic Type and accessibility-friendly rows

### Resolved ops
- `list_scan_configs` (GET /api/v1/security/configs)

### Deferred
- None for this cluster. Scan configs are authored per repository via the existing repository Security tab (`GET/PUT /repositories/{key}/security`), which is already wired; this view is the missing read-only aggregate.

Closes #63
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

A path-pinning dispatch test (`listScanConfigsHitsConfigsPath`) drives the real `APIClient.listScanConfigs()` through the `RecordingTransport` and asserts the request hits `/api/v1/security/configs` via the `list_scan_configs` operation. A model mapping test (`scanConfigMaps`) covers the SDK to app-model conversion. Full suite green: 473 tests.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements