### PR TITLE
feat(ios): quality gates and health dashboard (read + evaluate_gate)

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		098B007AFDBBB928C7FC45AB /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72273F4294E6BC2DA2D09609 /* SearchView.swift */; };
 		09E8E5F42512233704B3A4F6 /* LicensePoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */; };
 		0AB4F8101A72D6C81B34D496 /* BuildsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E5BB60BE578603D5B6925 /* BuildsView.swift */; };
+		0BC68220DEF68CF93D468766 /* QualityMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF539B04F8B6390EDFE0643B /* QualityMapping.swift */; };
 		0CD3534A62BFE963B4793311 /* VirtualMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F508C0FBF498EB51BC64EE /* VirtualMember.swift */; };
 		0D2124206E78085A90971F0A /* GroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1464BFA481535D3C3B4F4CC5 /* GroupsView.swift */; };
 		0D70D77C1E016F19CA722D51 /* PromotionHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFEA6435742230170CF65E1 /* PromotionHistoryView.swift */; };
@@ -42,6 +43,7 @@
 		28EDDF86319305C5ABC398D0 /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CFB90021A1428D8962F1BF /* Operations.swift */; };
 		293314A1B0346F707F5B3CE4 /* PluginPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4147C420ECCBB9137917722C /* PluginPathTests.swift */; };
 		2BBCC7E1EFC1A7A5C06BD188 /* SecurityDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */; };
+		2C4CA9F46F0C6F9AB72EDFE8 /* QualityGatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFF1C0C6841D1BF61141BD7 /* QualityGatesView.swift */; };
 		2D8B1BCF039F334B0A7FD76A /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9415E01C2D644848CDBB4D0 /* Theme.swift */; };
 		2DDFD6ABC4E15C7FFF7C72C5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1164C99171DC47A99F71C0D /* Assets.xcassets */; };
 		2DF3D0BF26A304169BB030CD /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3412EF9765589F0F5C9613ED /* APIClient.swift */; };
@@ -64,6 +66,7 @@
 		45EF793A77005F62C4263D1E /* WebhookPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D532EA4136F5C5CF5548AE /* WebhookPathTests.swift */; };
 		475F7C0CA9365AB11D952814 /* ReplicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8067728F7917AD61F0DB4037 /* ReplicationView.swift */; };
 		47DFA7F8B01E5A21906642A2 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DDB4F8B15C1FB99A2843 /* Package.swift */; };
+		4A9D08A77DCBD1954B4CB334 /* Quality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28281FCD705C9F9F4DF23AF7 /* Quality.swift */; };
 		4BA74F65F09BD28BC25CC705 /* RepositoryTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435C7C6ACC4028C205301D14 /* RepositoryTreeTests.swift */; };
 		4BB5107B04DD21BF5EC76FB0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8267620B852D7914EAD83DAE /* SettingsView.swift */; };
 		4BE83BE4509F6A9FBAC7EA93 /* RepoSecurityConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746DB83A1B571F5CDFDD791E /* RepoSecurityConfigView.swift */; };
@@ -94,6 +97,7 @@
 		661675A6E9DC360473BAA181 /* ArtifactDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE2C5256F844F6279846227 /* ArtifactDetail.swift */; };
 		66342C499ECF4ADDCCF83FFC /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341E812182C7DEF2DE15BDE6 /* AuthManager.swift */; };
 		67018A342717D2F56ADA6F58 /* TOTPVerificationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */; };
+		6D02C2A0C45C6E1D0AA70FE2 /* HealthDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AB45AA08A0DE4EA42BC041 /* HealthDashboardView.swift */; };
 		6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */; };
 		706149420AF74CC3C2F55FDB /* PoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */; };
 		71DE9560CF0DC604499711B9 /* ServerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */; };
@@ -105,6 +109,7 @@
 		7926AACBA3FC6E057D5340FE /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C4236474392052DD29004F /* DashboardView.swift */; };
 		797AE3D1C3726C2AAA195E4D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3E2D65A21BA60C8957EE36 /* ContentView.swift */; };
 		7B983BDEC8F0E8548B9E7E5E /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1901D688CCAD3DE71AA681AC /* APIClientTests.swift */; };
+		7C9F12D37482E704E49A3814 /* HealthDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AB45AA08A0DE4EA42BC041 /* HealthDashboardView.swift */; };
 		7E2E910B688E7F6C2455AA9A /* VirtualMembersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5897003BAFB18AFF0865CCEC /* VirtualMembersView.swift */; };
 		7E3F4ECD8B702F2A2DF45974 /* VirtualMembersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5897003BAFB18AFF0865CCEC /* VirtualMembersView.swift */; };
 		8227BD7FC4FA90F1EDDE2662 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79512BEEB0DBDA10DFDCFAAC /* MainTabView.swift */; };
@@ -116,11 +121,13 @@
 		859514D003E6E75A90E88192 /* UsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8761FACD0287EF99C0A1E50 /* UsersView.swift */; };
 		85BE46E9B704E5E25509D2FC /* APIClientExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */; };
 		85BE9083FC33581A5290D269 /* SecuritySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD29BEA4F2708262CE34F2E3 /* SecuritySectionView.swift */; };
+		868F52C07277B589BE29205D /* QualityMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8211F9D04C3BF74AB42324D9 /* QualityMappingTests.swift */; };
 		87DFC05DFE36A27A9C5769A6 /* EditRepositorySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0896BDB350847081B1C7EA3 /* EditRepositorySheet.swift */; };
 		8D14D0F52AF6E89139D3264B /* RepoUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C1CC3C4956018E653EC486 /* RepoUploadView.swift */; };
 		8DA5C4E619111D09EF7AB2B2 /* PromotionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F34D6E71603103BC21FD8EA /* PromotionSheet.swift */; };
 		8E465463A8632687E3C4C423 /* Build.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90190CE35DA804C357A5FFDB /* Build.swift */; };
 		8F03693614D04D4C4BE9C332 /* Security.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D8118DAD8066C9D0EED317C /* Security.swift */; };
+		914F9F60919A6E3B56627D31 /* QualityMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF539B04F8B6390EDFE0643B /* QualityMapping.swift */; };
 		93CA8B7CD50723325BB01412 /* StagingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F60553EA149CE733245164B /* StagingDetailView.swift */; };
 		940EE1C50954FCE0AE11F202 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3412EF9765589F0F5C9613ED /* APIClient.swift */; };
 		94F8DAE6FEDABE840D272740 /* AccountToolbarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A527DEEF9DECA3F2E8EC26 /* AccountToolbarModifier.swift */; };
@@ -134,6 +141,7 @@
 		9F313A124D557820A4F7F737 /* RepoSecurityConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */; };
 		9FBBA3D5EAF49575952C78AD /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = F35A063FFE69F8B8A3CD7AEE /* OpenAPIURLSession */; };
 		A1A538DE905D6AF031923CF5 /* AuthManagerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */; };
+		A481D0536AA2B6EEBA080174 /* QualityGatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFF1C0C6841D1BF61141BD7 /* QualityGatesView.swift */; };
 		A563ADC6B11F45AB50692ABA /* ScanConfigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */; };
 		A6FE919357227C480B8571C0 /* RepositoryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862E1C3205340290276A9B75 /* RepositoryTree.swift */; };
 		ABC754B5DC49717B25A912DB /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59705D3B5F2000ACABB8A48 /* Auth.swift */; };
@@ -165,6 +173,7 @@
 		C271C3B782A35CE71284249F /* Promotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CA7F1FBDE367A6D4052F47 /* Promotion.swift */; };
 		C42665F0C144A44BC7AAA95D /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15E45652EBB4DD2505127F /* WelcomeView.swift */; };
 		C485A2CE45918DADE34AAA1B /* SecurityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7351368D8EDB157E264ECBBC /* SecurityView.swift */; };
+		C9B9A7C9E5C3C1D29584E1DA /* Quality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28281FCD705C9F9F4DF23AF7 /* Quality.swift */; };
 		CB1B30416205DE75103AE1EC /* ArtifactKeeperClient in Frameworks */ = {isa = PBXBuildFile; productRef = 55A6201C43E26F452A85B4AC /* ArtifactKeeperClient */; };
 		CB9F64C28FEBB032DD2210F6 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FB2391848A9D7A02E4F7DC /* Repository.swift */; };
 		CBA92159E5A5DFC00F6CBC28 /* RepositoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9688E0041F1683C5DDFA6071 /* RepositoriesView.swift */; };
@@ -185,6 +194,7 @@
 		DD9C336F7D973FA27ACD095E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155377690C14964BAFBAF481 /* ProfileView.swift */; };
 		DF321600060A4DA7993785FF /* Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBE59905B179E64919791A7 /* Admin.swift */; };
 		DF3A3118CF4C5C19CDC19B56 /* VirtualMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F508C0FBF498EB51BC64EE /* VirtualMember.swift */; };
+		E15A1D5EA6FDA4D8DAF42CF7 /* QualityMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8211F9D04C3BF74AB42324D9 /* QualityMappingTests.swift */; };
 		E18E74AC77451E6C0022B276 /* Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBE59905B179E64919791A7 /* Admin.swift */; };
 		E2678146D7F808D22B485573 /* SecurityDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */; };
 		E4618623F8473A8661B7CC6F /* ChangePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7812397531D2CD01F4488BC6 /* ChangePasswordView.swift */; };
@@ -237,6 +247,7 @@
 		1901D688CCAD3DE71AA681AC /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		1DB4EEF15843269173A9B772 /* TOTPVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPVerificationView.swift; sourceTree = "<group>"; };
 		26F832901A43DC98CC288AA4 /* ArtifactSecurityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSecurityView.swift; sourceTree = "<group>"; };
+		28281FCD705C9F9F4DF23AF7 /* Quality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quality.swift; sourceTree = "<group>"; };
 		3412EF9765589F0F5C9613ED /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		341E812182C7DEF2DE15BDE6 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		36F508C0FBF498EB51BC64EE /* VirtualMember.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMember.swift; sourceTree = "<group>"; };
@@ -274,6 +285,7 @@
 		7FEF3A0FA55ECC63DDC8899F /* RepositoryDetailTabbedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailTabbedView.swift; sourceTree = "<group>"; };
 		8063DEF3B0228C26496797B7 /* WebhooksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhooksView.swift; sourceTree = "<group>"; };
 		8067728F7917AD61F0DB4037 /* ReplicationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplicationView.swift; sourceTree = "<group>"; };
+		8211F9D04C3BF74AB42324D9 /* QualityMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityMappingTests.swift; sourceTree = "<group>"; };
 		8267620B852D7914EAD83DAE /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8343AC1EF5CDAEE5D335C0F0 /* ArtifactKeeperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArtifactKeeperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		846E4EAE3F90ADE47BE07930 /* StagingSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagingSectionView.swift; sourceTree = "<group>"; };
@@ -306,8 +318,11 @@
 		C8A1761272FDDB00A7D41243 /* ArtifactKeeperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactKeeperTests.swift; sourceTree = "<group>"; };
 		C8F6787AE2A18008C8EA282F /* MonitoringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitoringView.swift; sourceTree = "<group>"; };
 		CAF4590E6775407858BBAC86 /* SecurityMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityMappingTests.swift; sourceTree = "<group>"; };
+		CCFF1C0C6841D1BF61141BD7 /* QualityGatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityGatesView.swift; sourceTree = "<group>"; };
+		CF539B04F8B6390EDFE0643B /* QualityMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualityMapping.swift; sourceTree = "<group>"; };
 		D217BC8D6B2994A881C4E04E /* ArtifactKeeperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactKeeperApp.swift; sourceTree = "<group>"; };
 		D4252913A5015A9448F73683 /* TelemetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryView.swift; sourceTree = "<group>"; };
+		D5AB45AA08A0DE4EA42BC041 /* HealthDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthDashboardView.swift; sourceTree = "<group>"; };
 		DC2FE890E60756D1FFA94CD1 /* ArtifactKeeper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ArtifactKeeper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerManager.swift; sourceTree = "<group>"; };
 		E59705D3B5F2000ACABB8A48 /* Auth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Auth.swift; sourceTree = "<group>"; };
@@ -405,6 +420,7 @@
 				AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */,
 				942CFADFFB28FA592F32CAB1 /* ModelTests.swift */,
 				4147C420ECCBB9137917722C /* PluginPathTests.swift */,
+				8211F9D04C3BF74AB42324D9 /* QualityMappingTests.swift */,
 				435C7C6ACC4028C205301D14 /* RepositoryTreeTests.swift */,
 				F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */,
 				CAF4590E6775407858BBAC86 /* SecurityMappingTests.swift */,
@@ -434,8 +450,10 @@
 				26F832901A43DC98CC288AA4 /* ArtifactSecurityView.swift */,
 				59106973EB99FD9424D44224 /* DtDashboardView.swift */,
 				07736CEE9959BC4566162E12 /* DtProjectsView.swift */,
+				D5AB45AA08A0DE4EA42BC041 /* HealthDashboardView.swift */,
 				5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */,
 				387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */,
+				CCFF1C0C6841D1BF61141BD7 /* QualityGatesView.swift */,
 				AACFAEE53DF20945E710A82E /* SbomView.swift */,
 				AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */,
 				7351368D8EDB157E264ECBBC /* SecurityView.swift */,
@@ -466,6 +484,7 @@
 				C5CFB90021A1428D8962F1BF /* Operations.swift */,
 				B6F9DDB4F8B15C1FB99A2843 /* Package.swift */,
 				C7CA7F1FBDE367A6D4052F47 /* Promotion.swift */,
+				28281FCD705C9F9F4DF23AF7 /* Quality.swift */,
 				ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */,
 				75FB2391848A9D7A02E4F7DC /* Repository.swift */,
 				862E1C3205340290276A9B75 /* RepositoryTree.swift */,
@@ -596,6 +615,7 @@
 			isa = PBXGroup;
 			children = (
 				3412EF9765589F0F5C9613ED /* APIClient.swift */,
+				CF539B04F8B6390EDFE0643B /* QualityMapping.swift */,
 				974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */,
 				AC7BD8467BED7C0A6ECE6DBE /* SecurityMapping.swift */,
 				E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */,
@@ -841,6 +861,7 @@
 				ECE469E91BEE0E35EB258F98 /* KeychainManagerTests.swift in Sources */,
 				FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */,
 				293314A1B0346F707F5B3CE4 /* PluginPathTests.swift in Sources */,
+				E15A1D5EA6FDA4D8DAF42CF7 /* QualityMappingTests.swift in Sources */,
 				1A02AD83B2F212120BFC892A /* RepositoryTreeTests.swift in Sources */,
 				E2678146D7F808D22B485573 /* SecurityDispatchTests.swift in Sources */,
 				EC57A5F27A84651FE192BC0A /* SecurityMappingTests.swift in Sources */,
@@ -879,6 +900,7 @@
 				B42C3893B88FDD3E8D354DB5 /* DtProjectsView.swift in Sources */,
 				87DFC05DFE36A27A9C5769A6 /* EditRepositorySheet.swift in Sources */,
 				B711A4EF6DF167F16406CBD3 /* GroupsView.swift in Sources */,
+				6D02C2A0C45C6E1D0AA70FE2 /* HealthDashboardView.swift in Sources */,
 				2EE7333E8775B1BB8124E0B7 /* Integration.swift in Sources */,
 				634179231AD90932820E8519 /* IntegrationSectionView.swift in Sources */,
 				B7F76BE14A732DCCD7EDF405 /* KeychainManager.swift in Sources */,
@@ -897,6 +919,9 @@
 				55E48C58A4F43DC5DC868FE0 /* Promotion.swift in Sources */,
 				145F250E51703B74FF907E4A /* PromotionHistoryView.swift in Sources */,
 				129B0BFC5316B0B5D0353E96 /* PromotionSheet.swift in Sources */,
+				C9B9A7C9E5C3C1D29584E1DA /* Quality.swift in Sources */,
+				2C4CA9F46F0C6F9AB72EDFE8 /* QualityGatesView.swift in Sources */,
+				914F9F60919A6E3B56627D31 /* QualityMapping.swift in Sources */,
 				D40F5A35411ACBE8737D54F7 /* ReplicationView.swift in Sources */,
 				9F313A124D557820A4F7F737 /* RepoSecurityConfig.swift in Sources */,
 				4BE83BE4509F6A9FBAC7EA93 /* RepoSecurityConfigView.swift in Sources */,
@@ -949,6 +974,7 @@
 				6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */,
 				83D01D48B7B7C3739E1344B3 /* ModelTests.swift in Sources */,
 				B18AAE17086834FBB57455D9 /* PluginPathTests.swift in Sources */,
+				868F52C07277B589BE29205D /* QualityMappingTests.swift in Sources */,
 				4BA74F65F09BD28BC25CC705 /* RepositoryTreeTests.swift in Sources */,
 				2BBCC7E1EFC1A7A5C06BD188 /* SecurityDispatchTests.swift in Sources */,
 				BF54F129B023787CC9A44249 /* SecurityMappingTests.swift in Sources */,
@@ -987,6 +1013,7 @@
 				B21993AEB170DF2F11F595FC /* DtProjectsView.swift in Sources */,
 				638F88CF707835320776D7D7 /* EditRepositorySheet.swift in Sources */,
 				0D2124206E78085A90971F0A /* GroupsView.swift in Sources */,
+				7C9F12D37482E704E49A3814 /* HealthDashboardView.swift in Sources */,
 				5E0D22452C4DCD3E0ECCEED2 /* Integration.swift in Sources */,
 				C0067BC56E14F7597CD91596 /* IntegrationSectionView.swift in Sources */,
 				D7AD6E41B44AF34DF7994C57 /* KeychainManager.swift in Sources */,
@@ -1005,6 +1032,9 @@
 				C271C3B782A35CE71284249F /* Promotion.swift in Sources */,
 				0D70D77C1E016F19CA722D51 /* PromotionHistoryView.swift in Sources */,
 				8DA5C4E619111D09EF7AB2B2 /* PromotionSheet.swift in Sources */,
+				4A9D08A77DCBD1954B4CB334 /* Quality.swift in Sources */,
+				A481D0536AA2B6EEBA080174 /* QualityGatesView.swift in Sources */,
+				0BC68220DEF68CF93D468766 /* QualityMapping.swift in Sources */,
 				475F7C0CA9365AB11D952814 /* ReplicationView.swift in Sources */,
 				B2BDDB70803CC764E1147668 /* RepoSecurityConfig.swift in Sources */,
 				B596C3D83FBAFD453E1E20DD /* RepoSecurityConfigView.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -777,6 +777,43 @@ actor APIClient {
         return data.map { ScanConfig(from: $0) }
     }
 
+    // MARK: Quality Gates & Health (SDK-backed)
+
+    /// List quality gate definitions (GET /api/v1/quality/gates).
+    func listQualityGates() async throws -> [QualityGate] {
+        let client = await sdkClientInstance()
+        let response = try await client.list_gates()
+        let data = try response.ok.body.json
+        return data.map { QualityGate(from: $0) }
+    }
+
+    /// Fetch a single quality gate (GET /api/v1/quality/gates/{id}).
+    func getQualityGate(id: String) async throws -> QualityGate {
+        let client = await sdkClientInstance()
+        let response = try await client.get_gate(path: .init(id: id))
+        let data = try response.ok.body.json
+        return QualityGate(from: data)
+    }
+
+    /// Evaluate gates against an artifact (POST /api/v1/quality/gates/evaluate/{artifact_id}).
+    func evaluateGate(artifactId: String, repositoryId: String? = nil) async throws -> GateEvaluation {
+        let client = await sdkClientInstance()
+        let response = try await client.evaluate_gate(
+            path: .init(artifact_id: artifactId),
+            query: .init(repository_id: repositoryId)
+        )
+        let data = try response.ok.body.json
+        return GateEvaluation(from: data)
+    }
+
+    /// Fetch the quality health dashboard (GET /api/v1/quality/health/dashboard).
+    func getHealthDashboard() async throws -> HealthDashboard {
+        let client = await sdkClientInstance()
+        let response = try await client.get_health_dashboard()
+        let data = try response.ok.body.json
+        return HealthDashboard(from: data)
+    }
+
     // MARK: SBOM (SDK-backed)
 
     /// Fetch the SBOM summary for an artifact (GET /api/v1/sbom/by-artifact/{artifact_id}).

--- a/ArtifactKeeper/Sources/Core/API/QualityMapping.swift
+++ b/ArtifactKeeper/Sources/Core/API/QualityMapping.swift
@@ -1,0 +1,116 @@
+import Foundation
+import ArtifactKeeperClient
+import OpenAPIRuntime
+
+// MARK: - SDK -> App Model Mapping (Quality Gates & Health)
+//
+// Mirrors SecurityMapping: the generated client returns snake_case fields, Int32
+// counts and Foundation.Date timestamps; the view layer uses the camelCase models
+// in Core/Models/Quality.swift with Int and ISO8601 date strings. Keeping the
+// conversions here makes them testable without a live server.
+
+extension QualityGate {
+    init(from sdk: Components.Schemas.GateResponse) {
+        self.init(
+            id: sdk.id,
+            name: sdk.name,
+            description: sdk.description,
+            repositoryId: sdk.repository_id,
+            action: sdk.action,
+            isEnabled: sdk.is_enabled,
+            enforceOnPromotion: sdk.enforce_on_promotion,
+            enforceOnDownload: sdk.enforce_on_download,
+            requiredChecks: sdk.required_checks,
+            minHealthScore: sdk.min_health_score.map(Int.init),
+            minQualityScore: sdk.min_quality_score.map(Int.init),
+            minSecurityScore: sdk.min_security_score.map(Int.init),
+            minMetadataScore: sdk.min_metadata_score.map(Int.init),
+            maxCriticalIssues: sdk.max_critical_issues.map(Int.init),
+            maxHighIssues: sdk.max_high_issues.map(Int.init),
+            maxMediumIssues: sdk.max_medium_issues.map(Int.init),
+            createdAt: SecurityMapping.isoString(sdk.created_at),
+            updatedAt: SecurityMapping.isoString(sdk.updated_at)
+        )
+    }
+}
+
+extension GateViolation {
+    init(from sdk: Components.Schemas.GateViolationResponse) {
+        self.init(
+            rule: sdk.rule,
+            expected: sdk.expected,
+            actual: sdk.actual,
+            message: sdk.message
+        )
+    }
+}
+
+extension GateEvaluation {
+    init(from sdk: Components.Schemas.GateEvaluationResponse) {
+        self.init(
+            passed: sdk.passed,
+            action: sdk.action,
+            gateName: sdk.gate_name,
+            healthScore: Int(sdk.health_score),
+            healthGrade: sdk.health_grade,
+            violations: sdk.violations.map { GateViolation(from: $0) },
+            componentScores: QualityMapping.numericScores(sdk.component_scores)
+        )
+    }
+}
+
+extension RepoHealth {
+    init(from sdk: Components.Schemas.RepoHealthResponse) {
+        self.init(
+            repositoryId: sdk.repository_id,
+            repositoryKey: sdk.repository_key,
+            healthScore: Int(sdk.health_score),
+            healthGrade: sdk.health_grade,
+            artifactsEvaluated: Int(sdk.artifacts_evaluated),
+            artifactsPassing: Int(sdk.artifacts_passing),
+            artifactsFailing: Int(sdk.artifacts_failing),
+            avgSecurityScore: sdk.avg_security_score.map(Int.init),
+            avgQualityScore: sdk.avg_quality_score.map(Int.init),
+            avgMetadataScore: sdk.avg_metadata_score.map(Int.init),
+            avgLicenseScore: sdk.avg_license_score.map(Int.init),
+            lastEvaluatedAt: sdk.last_evaluated_at.map(SecurityMapping.isoString)
+        )
+    }
+}
+
+extension HealthDashboard {
+    init(from sdk: Components.Schemas.HealthDashboardResponse) {
+        self.init(
+            totalRepositories: Int(sdk.total_repositories),
+            totalArtifactsEvaluated: Int(sdk.total_artifacts_evaluated),
+            avgHealthScore: Int(sdk.avg_health_score),
+            reposGradeA: Int(sdk.repos_grade_a),
+            reposGradeB: Int(sdk.repos_grade_b),
+            reposGradeC: Int(sdk.repos_grade_c),
+            reposGradeD: Int(sdk.repos_grade_d),
+            reposGradeF: Int(sdk.repos_grade_f),
+            repositories: sdk.repositories.map { RepoHealth(from: $0) }
+        )
+    }
+}
+
+// MARK: - Helpers
+
+enum QualityMapping {
+    /// Extract integer component scores from the free-form `component_scores`
+    /// object. The backend returns numeric scores keyed by component name
+    /// (security, quality, metadata, ...). Non-numeric values are dropped.
+    static func numericScores(_ container: OpenAPIObjectContainer) -> [String: Int] {
+        var result: [String: Int] = [:]
+        for (key, value) in container.value {
+            if let intValue = value as? Int {
+                result[key] = intValue
+            } else if let doubleValue = value as? Double {
+                result[key] = Int(doubleValue)
+            } else if let stringValue = value as? String, let parsed = Int(stringValue) {
+                result[key] = parsed
+            }
+        }
+        return result
+    }
+}

--- a/ArtifactKeeper/Sources/Core/Models/Quality.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Quality.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+// MARK: - Quality Gates & Health (1.2.1 /api/v1/quality/*)
+
+/// A quality gate definition (GET /api/v1/quality/gates, GET /api/v1/quality/gates/{id}).
+struct QualityGate: Codable, Identifiable, Sendable, Equatable {
+    let id: String
+    let name: String
+    let description: String?
+    let repositoryId: String?
+    let action: String
+    let isEnabled: Bool
+    let enforceOnPromotion: Bool
+    let enforceOnDownload: Bool
+    let requiredChecks: [String]
+    let minHealthScore: Int?
+    let minQualityScore: Int?
+    let minSecurityScore: Int?
+    let minMetadataScore: Int?
+    let maxCriticalIssues: Int?
+    let maxHighIssues: Int?
+    let maxMediumIssues: Int?
+    let createdAt: String
+    let updatedAt: String
+}
+
+/// A single rule violation from a gate evaluation.
+struct GateViolation: Codable, Identifiable, Sendable, Equatable {
+    let rule: String
+    let expected: String
+    let actual: String
+    let message: String
+
+    // Violations have no server-side id; derive a stable one from the rule.
+    var id: String { rule }
+}
+
+/// The result of evaluating a gate against an artifact
+/// (POST /api/v1/quality/gates/evaluate/{artifact_id}).
+struct GateEvaluation: Sendable, Equatable {
+    let passed: Bool
+    let action: String
+    let gateName: String
+    let healthScore: Int
+    let healthGrade: String
+    let violations: [GateViolation]
+    /// Component score breakdown (e.g. security, quality, metadata). Numeric values
+    /// are extracted from the free-form `component_scores` object; non-numeric
+    /// entries are dropped.
+    let componentScores: [String: Int]
+}
+
+/// Per-repository health summary inside the health dashboard.
+struct RepoHealth: Codable, Identifiable, Sendable, Equatable {
+    let repositoryId: String
+    let repositoryKey: String
+    let healthScore: Int
+    let healthGrade: String
+    let artifactsEvaluated: Int
+    let artifactsPassing: Int
+    let artifactsFailing: Int
+    let avgSecurityScore: Int?
+    let avgQualityScore: Int?
+    let avgMetadataScore: Int?
+    let avgLicenseScore: Int?
+    let lastEvaluatedAt: String?
+
+    var id: String { repositoryId }
+}
+
+/// The quality health dashboard (GET /api/v1/quality/health/dashboard).
+struct HealthDashboard: Sendable, Equatable {
+    let totalRepositories: Int
+    let totalArtifactsEvaluated: Int
+    let avgHealthScore: Int
+    let reposGradeA: Int
+    let reposGradeB: Int
+    let reposGradeC: Int
+    let reposGradeD: Int
+    let reposGradeF: Int
+    let repositories: [RepoHealth]
+}

--- a/ArtifactKeeper/Sources/Features/Security/HealthDashboardView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/HealthDashboardView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// Quality health dashboard (GET /api/v1/quality/health/dashboard). Shows the
+/// portfolio-wide averages and grade distribution, plus a per-repository health
+/// breakdown.
+struct HealthDashboardView: View {
+    @State private var dashboard: HealthDashboard?
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading health dashboard\u{2026}")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                ContentUnavailableView {
+                    Label("Dashboard Unavailable", systemImage: "heart.text.square")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Retry") { Task { await load() } }
+                        .buttonStyle(.borderedProminent)
+                }
+            } else if let dashboard {
+                List {
+                    Section("Overview") {
+                        overviewRow("Repositories", "\(dashboard.totalRepositories)")
+                        overviewRow("Artifacts Evaluated", "\(dashboard.totalArtifactsEvaluated)")
+                        HStack {
+                            Text("Average Health Score")
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text("\(dashboard.avgHealthScore)")
+                                .font(.headline)
+                        }
+                        .font(.subheadline)
+                    }
+
+                    Section("Grade Distribution") {
+                        gradeRow("A", dashboard.reposGradeA, .green)
+                        gradeRow("B", dashboard.reposGradeB, .mint)
+                        gradeRow("C", dashboard.reposGradeC, .yellow)
+                        gradeRow("D", dashboard.reposGradeD, .orange)
+                        gradeRow("F", dashboard.reposGradeF, .red)
+                    }
+
+                    if dashboard.repositories.isEmpty {
+                        Section("Repositories") {
+                            Text("No repositories have been evaluated yet.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Section("Repositories") {
+                            ForEach(dashboard.repositories) { repo in
+                                RepoHealthRow(repo: repo)
+                            }
+                        }
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .refreshable { await load() }
+        .task { await load() }
+    }
+
+    private func load() async {
+        isLoading = dashboard == nil
+        do {
+            dashboard = try await apiClient.getHealthDashboard()
+            errorMessage = nil
+        } catch {
+            if dashboard == nil {
+                errorMessage = "Could not load the health dashboard. You may need admin privileges."
+            }
+        }
+        isLoading = false
+    }
+
+    private func overviewRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+        }
+        .font(.subheadline)
+    }
+
+    private func gradeRow(_ grade: String, _ count: Int, _ color: Color) -> some View {
+        HStack {
+            Text("Grade \(grade)")
+                .foregroundStyle(color)
+            Spacer()
+            Text("\(count)")
+                .font(.subheadline.weight(.semibold))
+        }
+        .font(.subheadline)
+    }
+}
+
+private struct RepoHealthRow: View {
+    let repo: RepoHealth
+
+    var body: some View {
+        HStack(spacing: 12) {
+            GradeBadge(grade: repo.healthGrade)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(repo.repositoryKey)
+                    .font(.headline)
+                    .lineLimit(1)
+                Text("Score \(repo.healthScore) \u{00B7} \(repo.artifactsPassing)/\(repo.artifactsEvaluated) passing")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Security/QualityGatesView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/QualityGatesView.swift
@@ -1,0 +1,339 @@
+import SwiftUI
+
+/// Quality gate definitions (GET /api/v1/quality/gates). Tapping a gate opens a
+/// detail screen that re-fetches the single gate by id
+/// (GET /api/v1/quality/gates/{id}) and lets the operator evaluate it against an
+/// artifact (POST /api/v1/quality/gates/evaluate/{artifact_id}).
+struct QualityGatesView: View {
+    @State private var gates: [QualityGate] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading quality gates\u{2026}")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                ContentUnavailableView {
+                    Label("Gates Unavailable", systemImage: "checkmark.seal")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Retry") { Task { await load() } }
+                        .buttonStyle(.borderedProminent)
+                }
+            } else if gates.isEmpty {
+                ContentUnavailableView(
+                    "No Quality Gates",
+                    systemImage: "checkmark.seal",
+                    description: Text("No quality gates are configured yet.")
+                )
+            } else {
+                List {
+                    ForEach(gates) { gate in
+                        NavigationLink {
+                            QualityGateDetailView(listGate: gate)
+                        } label: {
+                            QualityGateRow(gate: gate)
+                        }
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .refreshable { await load() }
+        .task { await load() }
+    }
+
+    private func load() async {
+        isLoading = gates.isEmpty
+        do {
+            gates = try await apiClient.listQualityGates()
+            errorMessage = nil
+        } catch {
+            if gates.isEmpty {
+                errorMessage = "Could not load quality gates. You may need admin privileges."
+            }
+        }
+        isLoading = false
+    }
+}
+
+private struct QualityGateRow: View {
+    let gate: QualityGate
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Image(systemName: gate.isEnabled ? "checkmark.seal.fill" : "seal")
+                    .foregroundStyle(gate.isEnabled ? Color.green : Color.secondary)
+                Text(gate.name)
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+                Text(gate.action.capitalized)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            if let description = gate.description, !description.isEmpty {
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            HStack(spacing: 8) {
+                if gate.enforceOnPromotion {
+                    GateTag(text: "Promotion", systemImage: "arrow.up.circle")
+                }
+                if gate.enforceOnDownload {
+                    GateTag(text: "Download", systemImage: "arrow.down.circle")
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct GateTag: View {
+    let text: String
+    let systemImage: String
+
+    var body: some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.accentColor.opacity(0.12))
+            .clipShape(Capsule())
+    }
+}
+
+/// Detail for one gate. Re-fetches the gate by id on appear so a stale list value
+/// is refreshed, and offers an evaluation sheet.
+struct QualityGateDetailView: View {
+    let listGate: QualityGate
+
+    @State private var fetched: QualityGate?
+    @State private var loadError: String?
+    @State private var showingEvaluate = false
+
+    private let apiClient = APIClient.shared
+
+    private var gate: QualityGate { fetched ?? listGate }
+
+    var body: some View {
+        List {
+            if let loadError {
+                Section {
+                    Label(loadError, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Gate") {
+                detailRow("Name", gate.name)
+                detailRow("Action", gate.action.capitalized)
+                detailRow("Enabled", gate.isEnabled ? "Yes" : "No")
+                detailRow("Enforce on Promotion", gate.enforceOnPromotion ? "Yes" : "No")
+                detailRow("Enforce on Download", gate.enforceOnDownload ? "Yes" : "No")
+            }
+
+            if let description = gate.description, !description.isEmpty {
+                Section("Description") {
+                    Text(description).font(.subheadline)
+                }
+            }
+
+            if !gate.requiredChecks.isEmpty {
+                Section("Required Checks") {
+                    ForEach(gate.requiredChecks, id: \.self) { check in
+                        Label(check, systemImage: "checkmark.circle")
+                            .font(.subheadline)
+                    }
+                }
+            }
+
+            Section("Thresholds") {
+                thresholdRow("Min Health Score", gate.minHealthScore)
+                thresholdRow("Min Quality Score", gate.minQualityScore)
+                thresholdRow("Min Security Score", gate.minSecurityScore)
+                thresholdRow("Min Metadata Score", gate.minMetadataScore)
+                thresholdRow("Max Critical Issues", gate.maxCriticalIssues)
+                thresholdRow("Max High Issues", gate.maxHighIssues)
+                thresholdRow("Max Medium Issues", gate.maxMediumIssues)
+            }
+
+            Section {
+                Button {
+                    showingEvaluate = true
+                } label: {
+                    Label("Evaluate Against Artifact", systemImage: "play.circle")
+                }
+            }
+        }
+        .navigationTitle(gate.name)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { await loadDetail() }
+        .refreshable { await loadDetail() }
+        .sheet(isPresented: $showingEvaluate) {
+            NavigationStack {
+                GateEvaluateView(gate: gate)
+            }
+        }
+    }
+
+    private func loadDetail() async {
+        do {
+            fetched = try await apiClient.getQualityGate(id: listGate.id)
+            loadError = nil
+        } catch {
+            loadError = "Showing cached details; could not refresh: \(error.localizedDescription)"
+        }
+    }
+
+    @ViewBuilder
+    private func thresholdRow(_ label: String, _ value: Int?) -> some View {
+        if let value {
+            detailRow(label, "\(value)")
+        }
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).multilineTextAlignment(.trailing)
+        }
+        .font(.subheadline)
+    }
+}
+
+/// Sheet that runs `evaluateGate` for an artifact id the operator types in.
+struct GateEvaluateView: View {
+    let gate: QualityGate
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var artifactId = ""
+    @State private var isEvaluating = false
+    @State private var result: GateEvaluation?
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Form {
+            Section("Artifact") {
+                TextField("Artifact ID", text: $artifactId)
+                    .textContentType(.none)
+                    #if os(iOS)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                    #endif
+            }
+
+            Section {
+                Button {
+                    Task { await evaluate() }
+                } label: {
+                    if isEvaluating {
+                        ProgressView()
+                    } else {
+                        Text("Evaluate")
+                    }
+                }
+                .disabled(artifactId.trimmingCharacters(in: .whitespaces).isEmpty || isEvaluating)
+            }
+
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
+            }
+
+            if let result {
+                Section("Result") {
+                    HStack {
+                        Image(systemName: result.passed ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(result.passed ? Color.green : Color.red)
+                        Text(result.passed ? "Passed" : "Failed")
+                            .font(.headline)
+                        Spacer()
+                        Text(result.action.capitalized)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    detailRow("Gate", result.gateName)
+                    detailRow("Health Score", "\(result.healthScore)")
+                    detailRow("Health Grade", result.healthGrade)
+                }
+
+                if !result.componentScores.isEmpty {
+                    Section("Component Scores") {
+                        ForEach(result.componentScores.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                            detailRow(key.capitalized, "\(value)")
+                        }
+                    }
+                }
+
+                if !result.violations.isEmpty {
+                    Section("Violations") {
+                        ForEach(result.violations) { violation in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(violation.rule)
+                                    .font(.subheadline.weight(.semibold))
+                                Text(violation.message)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text("Expected \(violation.expected), got \(violation.actual)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 2)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Evaluate Gate")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+    }
+
+    private func evaluate() async {
+        isEvaluating = true
+        errorMessage = nil
+        defer { isEvaluating = false }
+        let trimmed = artifactId.trimmingCharacters(in: .whitespaces)
+        do {
+            result = try await apiClient.evaluateGate(
+                artifactId: trimmed,
+                repositoryId: gate.repositoryId
+            )
+        } catch {
+            errorMessage = "Evaluation failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).multilineTextAlignment(.trailing)
+        }
+        .font(.subheadline)
+    }
+}

--- a/ArtifactKeeper/Sources/Sections/SecuritySectionView.swift
+++ b/ArtifactKeeper/Sources/Sections/SecuritySectionView.swift
@@ -8,7 +8,7 @@ struct SecuritySectionView: View {
             VStack(spacing: 0) {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 0) {
-                        ForEach(["dashboard", "scans", "configs", "policies", "licenses"], id: \.self) { tab in
+                        ForEach(["dashboard", "scans", "configs", "gates", "health", "policies", "licenses"], id: \.self) { tab in
                             Button {
                                 selectedTab = tab
                             } label: {
@@ -37,6 +37,10 @@ struct SecuritySectionView: View {
                         SecurityScansContentView()
                     case "configs":
                         ScanConfigsView()
+                    case "gates":
+                        QualityGatesView()
+                    case "health":
+                        HealthDashboardView()
                     case "policies":
                         PoliciesView()
                     case "licenses":
@@ -57,6 +61,8 @@ struct SecuritySectionView: View {
         case "dashboard": return "Dashboard"
         case "scans": return "Scans"
         case "configs": return "Configs"
+        case "gates": return "Gates"
+        case "health": return "Health"
         case "policies": return "Policies"
         case "licenses": return "Licenses"
         default: return tab.capitalized

--- a/ArtifactKeeper/Tests/QualityMappingTests.swift
+++ b/ArtifactKeeper/Tests/QualityMappingTests.swift
@@ -1,0 +1,157 @@
+import Testing
+import Foundation
+import OpenAPIRuntime
+import ArtifactKeeperClient
+@testable import ArtifactKeeper
+
+// Tests for the SDK -> app model mapping behind the Quality Gates and Health
+// dashboard screens. They exercise the conversion in isolation so generated SDK
+// field drift surfaces here rather than at runtime.
+
+@Suite("Quality SDK Mapping Tests")
+struct QualityMappingTests {
+
+    private static let created = Date(timeIntervalSince1970: 1_700_000_000)
+    private static let updated = Date(timeIntervalSince1970: 1_700_086_400)
+
+    @Test func qualityGateMapsAllFields() {
+        let sdk = Components.Schemas.GateResponse(
+            action: "block",
+            created_at: Self.created,
+            description: "Block risky artifacts",
+            enforce_on_download: true,
+            enforce_on_promotion: false,
+            id: "gate-1",
+            is_enabled: true,
+            max_critical_issues: 0,
+            max_high_issues: 2,
+            max_medium_issues: nil,
+            min_health_score: 80,
+            min_metadata_score: nil,
+            min_quality_score: 70,
+            min_security_score: 90,
+            name: "Production Gate",
+            repository_id: "repo-9",
+            required_checks: ["security", "metadata"],
+            updated_at: Self.updated
+        )
+
+        let model = QualityGate(from: sdk)
+
+        #expect(model.id == "gate-1")
+        #expect(model.name == "Production Gate")
+        #expect(model.description == "Block risky artifacts")
+        #expect(model.repositoryId == "repo-9")
+        #expect(model.action == "block")
+        #expect(model.isEnabled)
+        #expect(model.enforceOnDownload)
+        #expect(!model.enforceOnPromotion)
+        #expect(model.requiredChecks == ["security", "metadata"])
+        #expect(model.minHealthScore == 80)
+        #expect(model.minQualityScore == 70)
+        #expect(model.minSecurityScore == 90)
+        #expect(model.minMetadataScore == nil)
+        #expect(model.maxCriticalIssues == 0)
+        #expect(model.maxHighIssues == 2)
+        #expect(model.maxMediumIssues == nil)
+        #expect(model.createdAt == SecurityMapping.isoString(Self.created))
+        #expect(model.updatedAt == SecurityMapping.isoString(Self.updated))
+    }
+
+    @Test func gateViolationMaps() {
+        let sdk = Components.Schemas.GateViolationResponse(
+            actual: "3",
+            expected: "0",
+            message: "Too many critical issues",
+            rule: "max_critical_issues"
+        )
+
+        let model = GateViolation(from: sdk)
+
+        #expect(model.rule == "max_critical_issues")
+        #expect(model.expected == "0")
+        #expect(model.actual == "3")
+        #expect(model.message == "Too many critical issues")
+        #expect(model.id == "max_critical_issues")
+    }
+
+    @Test func gateEvaluationMapsAndExtractsNumericScores() throws {
+        let scores = try OpenAPIObjectContainer(unvalidatedValue: [
+            "security": 90,
+            "quality": 75,
+            "label": "ignored-non-numeric"
+        ])
+        let sdk = Components.Schemas.GateEvaluationResponse(
+            action: "warn",
+            component_scores: scores,
+            gate_name: "Production Gate",
+            health_grade: "B",
+            health_score: 82,
+            passed: false,
+            violations: [
+                Components.Schemas.GateViolationResponse(
+                    actual: "3", expected: "0", message: "criticals", rule: "max_critical_issues"
+                )
+            ]
+        )
+
+        let model = GateEvaluation(from: sdk)
+
+        #expect(!model.passed)
+        #expect(model.action == "warn")
+        #expect(model.gateName == "Production Gate")
+        #expect(model.healthScore == 82)
+        #expect(model.healthGrade == "B")
+        #expect(model.violations.count == 1)
+        #expect(model.componentScores["security"] == 90)
+        #expect(model.componentScores["quality"] == 75)
+        // Non-numeric values are dropped.
+        #expect(model.componentScores["label"] == nil)
+    }
+
+    @Test func healthDashboardMaps() throws {
+        let repo = Components.Schemas.RepoHealthResponse(
+            artifacts_evaluated: 10,
+            artifacts_failing: 3,
+            artifacts_passing: 7,
+            avg_license_score: 88,
+            avg_metadata_score: 70,
+            avg_quality_score: 75,
+            avg_security_score: 90,
+            health_grade: "B",
+            health_score: 80,
+            last_evaluated_at: Self.updated,
+            repository_id: "repo-1",
+            repository_key: "maven-prod"
+        )
+        let sdk = Components.Schemas.HealthDashboardResponse(
+            avg_health_score: 78,
+            repos_grade_a: 5,
+            repos_grade_b: 4,
+            repos_grade_c: 3,
+            repos_grade_d: 2,
+            repos_grade_f: 1,
+            repositories: [repo],
+            total_artifacts_evaluated: 120,
+            total_repositories: 15
+        )
+
+        let model = HealthDashboard(from: sdk)
+
+        #expect(model.totalRepositories == 15)
+        #expect(model.totalArtifactsEvaluated == 120)
+        #expect(model.avgHealthScore == 78)
+        #expect(model.reposGradeA == 5)
+        #expect(model.reposGradeF == 1)
+        #expect(model.repositories.count == 1)
+
+        let mappedRepo = try #require(model.repositories.first)
+        #expect(mappedRepo.repositoryKey == "maven-prod")
+        #expect(mappedRepo.healthGrade == "B")
+        #expect(mappedRepo.healthScore == 80)
+        #expect(mappedRepo.artifactsPassing == 7)
+        #expect(mappedRepo.artifactsFailing == 3)
+        #expect(mappedRepo.avgSecurityScore == 90)
+        #expect(mappedRepo.lastEvaluatedAt == SecurityMapping.isoString(Self.updated))
+    }
+}

--- a/ArtifactKeeper/Tests/SecurityDispatchTests.swift
+++ b/ArtifactKeeper/Tests/SecurityDispatchTests.swift
@@ -49,7 +49,7 @@ final class RecordingTransport: ClientTransport, @unchecked Sendable {
         switch operationID {
         case "list_artifact_scans", "list_findings":
             return #"{"items":[],"total":0}"#
-        case "get_sbom_components", "get_all_scores", "list_scan_configs":
+        case "get_sbom_components", "get_all_scores", "list_scan_configs", "list_gates":
             return "[]"
         default:
             return "{}"
@@ -192,5 +192,51 @@ struct SecurityDispatchTests {
         #expect(rec?.method == "GET")
         #expect(pathComponent(rec?.path) == "/api/v1/security/configs")
         #expect(rec?.operationID == "list_scan_configs")
+    }
+
+    // MARK: - Quality Gates & Health cluster
+
+    @Test func listQualityGatesHitsGatesPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try await api.listQualityGates()
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/quality/gates")
+        #expect(rec?.operationID == "list_gates")
+    }
+
+    @Test func getQualityGateHitsGateByIdPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.getQualityGate(id: "gate-3")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/quality/gates/gate-3")
+        #expect(rec?.operationID == "get_gate")
+    }
+
+    @Test func evaluateGateHitsEvaluatePath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.evaluateGate(artifactId: "art-42")
+
+        let rec = transport.last
+        #expect(rec?.method == "POST")
+        #expect(pathComponent(rec?.path) == "/api/v1/quality/gates/evaluate/art-42")
+        #expect(rec?.operationID == "evaluate_gate")
+    }
+
+    @Test func getHealthDashboardHitsDashboardPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.getHealthDashboard()
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/quality/health/dashboard")
+        #expect(rec?.operationID == "get_health_dashboard")
     }
 }


### PR DESCRIPTION
## Summary
Adds **Gates** and **Health** tabs to the Security section, wiring the quality subsystem.

**Gates** lists quality gate definitions (`GET /api/v1/quality/gates`). Tapping a gate opens a detail screen that re-fetches the single gate by id (`GET /api/v1/quality/gates/{id}`) on `.task`, then offers an evaluation sheet that runs the gate against an artifact id (`POST /api/v1/quality/gates/evaluate/{artifact_id}`) and shows pass/fail, action, health score and grade, the component score breakdown, and any rule violations.

**Health** renders the quality health dashboard (`GET /api/v1/quality/health/dashboard`): portfolio averages, grade distribution (A-F), and a per-repository health breakdown using the shared `GradeBadge`.

Implementation follows the existing SDK-backed Security style:
- `Quality` models (`QualityGate`, `GateEvaluation`, `GateViolation`, `HealthDashboard`, `RepoHealth`)
- `QualityMapping.swift` with `init(from:)` conversions; `component_scores` is a free-form object, so numeric entries are extracted and non-numeric ones dropped
- `APIClient` methods: `listQualityGates`, `getQualityGate`, `evaluateGate`, `getHealthDashboard`
- Views with loading / error-with-retry / empty states, refreshable, Dynamic Type, dark mode, accessibility-combined rows

### Resolved ops
- `list_gates` (GET /api/v1/quality/gates)
- `get_gate` (GET /api/v1/quality/gates/{id})
- `evaluate_gate` (POST /api/v1/quality/gates/evaluate/{artifact_id})
- `get_health_dashboard` (GET /api/v1/quality/health/dashboard)

### Deferred
- `create_gate` / `update_gate` / `delete_gate` -- free-form gate authoring
- `get_repo_health` (GET /api/v1/quality/health/repositories/{key}) and `get_artifact_health` (GET /api/v1/quality/health/artifacts/{artifact_id}) drilldowns

Closes #65
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Path-pinning dispatch tests drive the real `APIClient` methods through `RecordingTransport` and assert each hits the correct path and operation (`listQualityGatesHitsGatesPath`, `getQualityGateHitsGateByIdPath`, `evaluateGateHitsEvaluatePath`, `getHealthDashboardHitsDashboardPath`). Model mapping tests in `QualityMappingTests` cover the SDK to app-model conversions including numeric-score extraction. Full suite green: 480 tests.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements