### PR TITLE
feat(ios): repository-scoped scan history (list_repo_scans)

### DIFF
--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -722,6 +722,17 @@ actor APIClient {
         return data.items.map { ScanFinding(from: $0) }
     }
 
+    /// List scans for a single repository (GET /api/v1/repositories/{key}/security/scans).
+    func listRepoScans(repoKey: String) async throws -> [ScanResult] {
+        let client = await sdkClientInstance()
+        let response = try await client.list_repo_scans(
+            path: .init(key: repoKey),
+            query: .init(per_page: 100)
+        )
+        let data = try response.ok.body.json
+        return data.items.map { ScanResult(from: $0) }
+    }
+
     /// Security overview counts (GET /api/v1/security/dashboard).
     func getSecurityDashboard() async throws -> SecurityDashboard {
         let client = await sdkClientInstance()

--- a/ArtifactKeeper/Sources/Features/Repositories/RepoSecurityConfigView.swift
+++ b/ArtifactKeeper/Sources/Features/Repositories/RepoSecurityConfigView.swift
@@ -15,6 +15,10 @@ struct RepoSecurityConfigView: View {
     @State private var blockOnPolicyViolation = false
     @State private var severityThreshold = "high"
 
+    @State private var recentScans: [ScanResult] = []
+    @State private var isLoadingScans = true
+    @State private var scansError: String?
+
     private let apiClient = APIClient.shared
     private let thresholds = ["critical", "high", "medium", "low"]
 
@@ -34,6 +38,7 @@ struct RepoSecurityConfigView: View {
             }
         }
         .task { await loadConfig() }
+        .task { await loadRecentScans() }
     }
 
     private var configForm: some View {
@@ -83,8 +88,35 @@ struct RepoSecurityConfigView: View {
                 }
                 .disabled(isSaving)
             }
+
+            recentScansSection
         }
         .formStyle(.grouped)
+    }
+
+    @ViewBuilder
+    private var recentScansSection: some View {
+        Section("Recent Scans") {
+            if isLoadingScans {
+                HStack {
+                    ProgressView().controlSize(.small)
+                    Text("Loading scans\u{2026}")
+                        .foregroundStyle(.secondary)
+                }
+            } else if let scansError {
+                Label(scansError, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if recentScans.isEmpty {
+                Text("No scans have run for this repository yet.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(recentScans) { scan in
+                    RepoScanRow(scan: scan)
+                }
+            }
+        }
     }
 
     private func loadConfig() async {
@@ -127,5 +159,92 @@ struct RepoSecurityConfigView: View {
         }
 
         isSaving = false
+    }
+
+    private func loadRecentScans() async {
+        isLoadingScans = recentScans.isEmpty
+        do {
+            recentScans = try await apiClient.listRepoScans(repoKey: repoKey)
+            scansError = nil
+        } catch {
+            if recentScans.isEmpty {
+                scansError = "Could not load recent scans."
+            }
+        }
+        isLoadingScans = false
+    }
+}
+
+private struct RepoScanRow: View {
+    let scan: ScanResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: statusIcon)
+                    .foregroundStyle(statusColor)
+                Text(scan.artifactName ?? scan.artifactId)
+                    .font(.subheadline.weight(.medium))
+                    .lineLimit(1)
+                if let version = scan.artifactVersion, !version.isEmpty {
+                    Text(version)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(scan.status.capitalized)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(statusColor)
+            }
+
+            HStack(spacing: 6) {
+                if scan.criticalCount > 0 {
+                    severityPill(scan.criticalCount, "C", .red)
+                }
+                if scan.highCount > 0 {
+                    severityPill(scan.highCount, "H", .orange)
+                }
+                if scan.mediumCount > 0 {
+                    severityPill(scan.mediumCount, "M", .yellow)
+                }
+                if scan.lowCount > 0 {
+                    severityPill(scan.lowCount, "L", .blue)
+                }
+                if scan.findingsCount == 0 && scan.status.lowercased() == "completed" {
+                    Text("No findings")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var statusIcon: String {
+        switch scan.status.lowercased() {
+        case "completed": return "checkmark.circle.fill"
+        case "failed", "error": return "xmark.circle.fill"
+        case "running", "in_progress", "pending": return "clock.fill"
+        default: return "circle"
+        }
+    }
+
+    private var statusColor: Color {
+        switch scan.status.lowercased() {
+        case "completed": return scan.findingsCount > 0 ? .orange : .green
+        case "failed", "error": return .red
+        case "running", "in_progress", "pending": return .blue
+        default: return .secondary
+        }
+    }
+
+    private func severityPill(_ count: Int, _ label: String, _ color: Color) -> some View {
+        Text("\(count)\(label)")
+            .font(.caption2.weight(.bold))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15), in: Capsule())
+            .foregroundStyle(color)
     }
 }

--- a/ArtifactKeeper/Tests/SecurityDispatchTests.swift
+++ b/ArtifactKeeper/Tests/SecurityDispatchTests.swift
@@ -47,7 +47,7 @@ final class RecordingTransport: ClientTransport, @unchecked Sendable {
     /// decode failure does not affect the path/method assertions (callers use `try?`).
     private static func cannedBody(for operationID: String) -> String {
         switch operationID {
-        case "list_artifact_scans", "list_findings":
+        case "list_artifact_scans", "list_findings", "list_repo_scans":
             return #"{"items":[],"total":0}"#
         case "get_sbom_components", "get_all_scores", "list_scan_configs", "list_gates":
             return "[]"
@@ -238,5 +238,18 @@ struct SecurityDispatchTests {
         #expect(rec?.method == "GET")
         #expect(pathComponent(rec?.path) == "/api/v1/quality/health/dashboard")
         #expect(rec?.operationID == "get_health_dashboard")
+    }
+
+    // MARK: - Repository-scoped scans
+
+    @Test func listRepoScansHitsRepoScansPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try await api.listRepoScans(repoKey: "maven-prod")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/repositories/maven-prod/security/scans")
+        #expect(rec?.operationID == "list_repo_scans")
     }
 }


### PR DESCRIPTION
## Summary
Adds a **Recent Scans** section to the repository Security tab (`RepoSecurityConfigView`), listing scans for that repository via the proper per-repo endpoint `GET /api/v1/repositories/{key}/security/scans` (`list_repo_scans`).

Each row shows the scanned artifact (name and version when available), the scan status with a colored status icon, and per-severity finding counts (critical/high/medium/low pills, or "No findings" for a clean completed scan).

Implementation:
- `APIClient.listRepoScans(repoKey:)`, SDK-backed, reusing the existing `ScanResult(from: ScanResponse)` mapping
- Loads on `.task` alongside the config; inline loading / error / empty states in the form

The global Security dashboard previously approximated repo-scoped scans with `/api/v1/security/scans?repository_id=`; this wires the dedicated endpoint where it belongs (on the repository itself).

### Resolved ops
- `list_repo_scans` (GET /api/v1/repositories/{key}/security/scans)

### Deferred
- None for this op.

Closes #69
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

A path-pinning dispatch test (`listRepoScansHitsRepoScansPath`) drives the real `APIClient.listRepoScans(repoKey:)` through `RecordingTransport` with a runtime repo key and asserts the request hits `/api/v1/repositories/maven-prod/security/scans` via the `list_repo_scans` operation. Full suite green: 485 tests.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements