### PR TITLE
feat(ios): quality health drilldowns (get_repo_health, get_artifact_health)

### DIFF
--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -825,6 +825,22 @@ actor APIClient {
         return HealthDashboard(from: data)
     }
 
+    /// Health for a single repository (GET /api/v1/quality/health/repositories/{key}).
+    func getRepoHealth(repoKey: String) async throws -> RepoHealth {
+        let client = await sdkClientInstance()
+        let response = try await client.get_repo_health(path: .init(key: repoKey))
+        let data = try response.ok.body.json
+        return RepoHealth(from: data)
+    }
+
+    /// Health for a single artifact (GET /api/v1/quality/health/artifacts/{artifact_id}).
+    func getArtifactHealth(artifactId: String) async throws -> ArtifactHealth {
+        let client = await sdkClientInstance()
+        let response = try await client.get_artifact_health(path: .init(artifact_id: artifactId))
+        let data = try response.ok.body.json
+        return ArtifactHealth(from: data)
+    }
+
     // MARK: SBOM (SDK-backed)
 
     /// Fetch the SBOM summary for an artifact (GET /api/v1/sbom/by-artifact/{artifact_id}).

--- a/ArtifactKeeper/Sources/Core/API/QualityMapping.swift
+++ b/ArtifactKeeper/Sources/Core/API/QualityMapping.swift
@@ -78,6 +78,39 @@ extension RepoHealth {
     }
 }
 
+extension CheckSummary {
+    init(from sdk: Components.Schemas.CheckSummary) {
+        self.init(
+            checkType: sdk.check_type,
+            status: sdk.status,
+            issuesCount: Int(sdk.issues_count),
+            passed: sdk.passed,
+            score: sdk.score.map(Int.init),
+            completedAt: sdk.completed_at.map(SecurityMapping.isoString)
+        )
+    }
+}
+
+extension ArtifactHealth {
+    init(from sdk: Components.Schemas.ArtifactHealthResponse) {
+        self.init(
+            artifactId: sdk.artifact_id,
+            healthScore: Int(sdk.health_score),
+            healthGrade: sdk.health_grade,
+            totalIssues: Int(sdk.total_issues),
+            criticalIssues: Int(sdk.critical_issues),
+            checksPassed: Int(sdk.checks_passed),
+            checksTotal: Int(sdk.checks_total),
+            securityScore: sdk.security_score.map(Int.init),
+            qualityScore: sdk.quality_score.map(Int.init),
+            metadataScore: sdk.metadata_score.map(Int.init),
+            licenseScore: sdk.license_score.map(Int.init),
+            lastCheckedAt: sdk.last_checked_at.map(SecurityMapping.isoString),
+            checks: sdk.checks.map { CheckSummary(from: $0) }
+        )
+    }
+}
+
 extension HealthDashboard {
     init(from sdk: Components.Schemas.HealthDashboardResponse) {
         self.init(

--- a/ArtifactKeeper/Sources/Core/Models/Quality.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Quality.swift
@@ -68,6 +68,36 @@ struct RepoHealth: Codable, Identifiable, Sendable, Equatable {
     var id: String { repositoryId }
 }
 
+/// A single quality check summary inside an artifact health report.
+struct CheckSummary: Codable, Identifiable, Sendable, Equatable {
+    let checkType: String
+    let status: String
+    let issuesCount: Int
+    let passed: Bool?
+    let score: Int?
+    let completedAt: String?
+
+    // Checks have no server id; the check type is unique within a report.
+    var id: String { checkType }
+}
+
+/// Per-artifact health report (GET /api/v1/quality/health/artifacts/{artifact_id}).
+struct ArtifactHealth: Sendable, Equatable {
+    let artifactId: String
+    let healthScore: Int
+    let healthGrade: String
+    let totalIssues: Int
+    let criticalIssues: Int
+    let checksPassed: Int
+    let checksTotal: Int
+    let securityScore: Int?
+    let qualityScore: Int?
+    let metadataScore: Int?
+    let licenseScore: Int?
+    let lastCheckedAt: String?
+    let checks: [CheckSummary]
+}
+
 /// The quality health dashboard (GET /api/v1/quality/health/dashboard).
 struct HealthDashboard: Sendable, Equatable {
     let totalRepositories: Int

--- a/ArtifactKeeper/Sources/Features/Security/HealthDashboardView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/HealthDashboardView.swift
@@ -47,6 +47,14 @@ struct HealthDashboardView: View {
                         gradeRow("F", dashboard.reposGradeF, .red)
                     }
 
+                    Section("Artifact Health") {
+                        NavigationLink {
+                            ArtifactHealthLookupView()
+                        } label: {
+                            Label("Look up artifact health", systemImage: "magnifyingglass")
+                        }
+                    }
+
                     if dashboard.repositories.isEmpty {
                         Section("Repositories") {
                             Text("No repositories have been evaluated yet.")
@@ -56,7 +64,11 @@ struct HealthDashboardView: View {
                     } else {
                         Section("Repositories") {
                             ForEach(dashboard.repositories) { repo in
-                                RepoHealthRow(repo: repo)
+                                NavigationLink {
+                                    RepoHealthDetailView(repoKey: repo.repositoryKey, listRepo: repo)
+                                } label: {
+                                    RepoHealthRow(repo: repo)
+                                }
                             }
                         }
                     }
@@ -120,5 +132,234 @@ private struct RepoHealthRow: View {
         }
         .padding(.vertical, 4)
         .accessibilityElement(children: .combine)
+    }
+}
+
+/// Detail for one repository's health. Re-fetches by key on appear
+/// (GET /api/v1/quality/health/repositories/{key}) so a stale dashboard value is
+/// refreshed and the per-component average scores are shown.
+private struct RepoHealthDetailView: View {
+    let repoKey: String
+    let listRepo: RepoHealth
+
+    @State private var fetched: RepoHealth?
+    @State private var loadError: String?
+
+    private let apiClient = APIClient.shared
+
+    private var repo: RepoHealth { fetched ?? listRepo }
+
+    var body: some View {
+        List {
+            if let loadError {
+                Section {
+                    Label(loadError, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section {
+                HStack(spacing: 12) {
+                    GradeBadge(grade: repo.healthGrade)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(repo.repositoryKey).font(.headline)
+                        Text("Health score \(repo.healthScore)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section("Artifacts") {
+                detailRow("Evaluated", "\(repo.artifactsEvaluated)")
+                detailRow("Passing", "\(repo.artifactsPassing)")
+                detailRow("Failing", "\(repo.artifactsFailing)")
+            }
+
+            Section("Average Scores") {
+                scoreRow("Security", repo.avgSecurityScore)
+                scoreRow("Quality", repo.avgQualityScore)
+                scoreRow("Metadata", repo.avgMetadataScore)
+                scoreRow("License", repo.avgLicenseScore)
+            }
+        }
+        .navigationTitle(repo.repositoryKey)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { await loadDetail() }
+        .refreshable { await loadDetail() }
+    }
+
+    private func loadDetail() async {
+        do {
+            fetched = try await apiClient.getRepoHealth(repoKey: repoKey)
+            loadError = nil
+        } catch {
+            loadError = "Showing cached health; could not refresh: \(error.localizedDescription)"
+        }
+    }
+
+    @ViewBuilder
+    private func scoreRow(_ label: String, _ value: Int?) -> some View {
+        if let value {
+            detailRow(label, "\(value)")
+        }
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+        }
+        .font(.subheadline)
+    }
+}
+
+/// Look up a single artifact's health by id
+/// (GET /api/v1/quality/health/artifacts/{artifact_id}).
+private struct ArtifactHealthLookupView: View {
+    @State private var artifactId = ""
+    @State private var isLoading = false
+    @State private var hasSearched = false
+    @State private var health: ArtifactHealth?
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Form {
+            Section("Artifact") {
+                TextField("Artifact id", text: $artifactId)
+                    #if os(iOS)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                    #endif
+                    .onSubmit { Task { await lookup() } }
+                Button {
+                    Task { await lookup() }
+                } label: {
+                    if isLoading {
+                        ProgressView()
+                    } else {
+                        Text("Look Up Health")
+                    }
+                }
+                .disabled(artifactId.trimmingCharacters(in: .whitespaces).isEmpty || isLoading)
+            }
+
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
+            } else if !hasSearched {
+                Section {
+                    Text("Enter an artifact id to see its health score and check breakdown.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let health {
+                Section {
+                    HStack(spacing: 12) {
+                        GradeBadge(grade: health.healthGrade)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Health score \(health.healthScore)").font(.headline)
+                            Text("\(health.checksPassed)/\(health.checksTotal) checks passed")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Section("Issues") {
+                    detailRow("Total Issues", "\(health.totalIssues)")
+                    detailRow("Critical Issues", "\(health.criticalIssues)")
+                }
+
+                Section("Component Scores") {
+                    scoreRow("Security", health.securityScore)
+                    scoreRow("Quality", health.qualityScore)
+                    scoreRow("Metadata", health.metadataScore)
+                    scoreRow("License", health.licenseScore)
+                }
+
+                if !health.checks.isEmpty {
+                    Section("Checks") {
+                        ForEach(health.checks) { check in
+                            HStack {
+                                Image(systemName: checkIcon(check))
+                                    .foregroundStyle(checkColor(check))
+                                Text(check.checkType.capitalized)
+                                    .font(.subheadline)
+                                Spacer()
+                                if let score = check.score {
+                                    Text("\(score)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Text(check.status.capitalized)
+                                    .font(.caption2.weight(.semibold))
+                                    .foregroundStyle(checkColor(check))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Artifact Health")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    private func lookup() async {
+        let trimmed = artifactId.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        isLoading = true
+        errorMessage = nil
+        hasSearched = true
+        defer { isLoading = false }
+        do {
+            health = try await apiClient.getArtifactHealth(artifactId: trimmed)
+        } catch {
+            health = nil
+            errorMessage = "Could not load artifact health: \(error.localizedDescription)"
+        }
+    }
+
+    private func checkIcon(_ check: CheckSummary) -> String {
+        if let passed = check.passed {
+            return passed ? "checkmark.circle.fill" : "xmark.circle.fill"
+        }
+        return "circle"
+    }
+
+    private func checkColor(_ check: CheckSummary) -> Color {
+        if let passed = check.passed {
+            return passed ? .green : .red
+        }
+        return .secondary
+    }
+
+    @ViewBuilder
+    private func scoreRow(_ label: String, _ value: Int?) -> some View {
+        if let value {
+            detailRow(label, "\(value)")
+        }
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+        }
+        .font(.subheadline)
     }
 }

--- a/ArtifactKeeper/Tests/QualityMappingTests.swift
+++ b/ArtifactKeeper/Tests/QualityMappingTests.swift
@@ -154,4 +154,99 @@ struct QualityMappingTests {
         #expect(mappedRepo.avgSecurityScore == 90)
         #expect(mappedRepo.lastEvaluatedAt == SecurityMapping.isoString(Self.updated))
     }
+
+    @Test func repoHealthMaps() {
+        let sdk = Components.Schemas.RepoHealthResponse(
+            artifacts_evaluated: 12,
+            artifacts_failing: 4,
+            artifacts_passing: 8,
+            avg_license_score: 81,
+            avg_metadata_score: 72,
+            avg_quality_score: 77,
+            avg_security_score: 95,
+            health_grade: "A",
+            health_score: 91,
+            last_evaluated_at: Self.updated,
+            repository_id: "repo-7",
+            repository_key: "npm-prod"
+        )
+
+        let model = RepoHealth(from: sdk)
+
+        #expect(model.repositoryId == "repo-7")
+        #expect(model.repositoryKey == "npm-prod")
+        #expect(model.healthGrade == "A")
+        #expect(model.healthScore == 91)
+        #expect(model.artifactsEvaluated == 12)
+        #expect(model.artifactsPassing == 8)
+        #expect(model.artifactsFailing == 4)
+        #expect(model.avgSecurityScore == 95)
+        #expect(model.avgLicenseScore == 81)
+        #expect(model.lastEvaluatedAt == SecurityMapping.isoString(Self.updated))
+    }
+
+    @Test func checkSummaryMaps() {
+        let sdk = Components.Schemas.CheckSummary(
+            check_type: "security",
+            completed_at: Self.updated,
+            issues_count: 2,
+            passed: false,
+            score: 60,
+            status: "completed"
+        )
+
+        let model = CheckSummary(from: sdk)
+
+        #expect(model.checkType == "security")
+        #expect(model.status == "completed")
+        #expect(model.issuesCount == 2)
+        #expect(model.passed == false)
+        #expect(model.score == 60)
+        #expect(model.completedAt == SecurityMapping.isoString(Self.updated))
+        #expect(model.id == "security")
+    }
+
+    @Test func artifactHealthMaps() throws {
+        let sdk = Components.Schemas.ArtifactHealthResponse(
+            artifact_id: "art-1",
+            checks: [
+                Components.Schemas.CheckSummary(
+                    check_type: "metadata", completed_at: nil, issues_count: 0,
+                    passed: true, score: 100, status: "completed"
+                )
+            ],
+            checks_passed: 3,
+            checks_total: 4,
+            critical_issues: 1,
+            health_grade: "B",
+            health_score: 82,
+            last_checked_at: Self.updated,
+            license_score: 90,
+            metadata_score: 100,
+            quality_score: 70,
+            security_score: 85,
+            total_issues: 5
+        )
+
+        let model = ArtifactHealth(from: sdk)
+
+        #expect(model.artifactId == "art-1")
+        #expect(model.healthScore == 82)
+        #expect(model.healthGrade == "B")
+        #expect(model.totalIssues == 5)
+        #expect(model.criticalIssues == 1)
+        #expect(model.checksPassed == 3)
+        #expect(model.checksTotal == 4)
+        #expect(model.securityScore == 85)
+        #expect(model.qualityScore == 70)
+        #expect(model.metadataScore == 100)
+        #expect(model.licenseScore == 90)
+        #expect(model.lastCheckedAt == SecurityMapping.isoString(Self.updated))
+        #expect(model.checks.count == 1)
+
+        let check = try #require(model.checks.first)
+        #expect(check.checkType == "metadata")
+        #expect(check.passed == true)
+        #expect(check.completedAt == nil)
+    }
 }

--- a/ArtifactKeeper/Tests/SecurityDispatchTests.swift
+++ b/ArtifactKeeper/Tests/SecurityDispatchTests.swift
@@ -252,4 +252,28 @@ struct SecurityDispatchTests {
         #expect(pathComponent(rec?.path) == "/api/v1/repositories/maven-prod/security/scans")
         #expect(rec?.operationID == "list_repo_scans")
     }
+
+    // MARK: - Quality health drilldowns
+
+    @Test func getRepoHealthHitsRepoHealthPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.getRepoHealth(repoKey: "maven-prod")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/quality/health/repositories/maven-prod")
+        #expect(rec?.operationID == "get_repo_health")
+    }
+
+    @Test func getArtifactHealthHitsArtifactHealthPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.getArtifactHealth(artifactId: "art-88")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(pathComponent(rec?.path) == "/api/v1/quality/health/artifacts/art-88")
+        #expect(rec?.operationID == "get_artifact_health")
+    }
 }


### PR DESCRIPTION
## Summary
Wires the two per-target quality health reads into the Health tab.

**Per-repository drilldown**: each repository row in the health dashboard is now a NavigationLink to a repo-health detail that re-fetches by key on `.task` (`GET /api/v1/quality/health/repositories/{key}`), showing artifact pass/fail counts and the average security/quality/metadata/license scores.

**Artifact health lookup**: a new entry in the Health tab lets an operator enter an artifact id to fetch its health report (`GET /api/v1/quality/health/artifacts/{artifact_id}`): health score and grade, total and critical issues, component scores, and a per-check breakdown (icon + status + score).

Implementation follows the existing SDK-backed Quality style:
- `APIClient.getRepoHealth(repoKey:)` and `getArtifactHealth(artifactId:)`
- `RepoHealth` model reused from the dashboard; new `ArtifactHealth` + `CheckSummary` models with `QualityMapping` conversions
- Detail view re-fetches by id on `.task` (does not just reuse the list value), with loading / cached-with-refresh-error / empty states, Dynamic Type, dark mode

### Resolved ops
- `get_repo_health` (GET /api/v1/quality/health/repositories/{key})
- `get_artifact_health` (GET /api/v1/quality/health/artifacts/{artifact_id})

### Deferred
- None. This closes the quality health drilldowns called out as in-scope.

Closes #71
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Path-pinning dispatch tests drive the real methods through `RecordingTransport` with runtime ids and assert each hits the correct path/operation (`getRepoHealthHitsRepoHealthPath`, `getArtifactHealthHitsArtifactHealthPath`). Mapping tests cover `RepoHealth`, `CheckSummary`, and `ArtifactHealth` conversions. Full suite green: 490 tests.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements