### PR TITLE
feat(ios): plugin install from Git and uninstall

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		083E2EBD72FFCF6E3EDEA31B /* DtDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59106973EB99FD9424D44224 /* DtDashboardView.swift */; };
 		098B007AFDBBB928C7FC45AB /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72273F4294E6BC2DA2D09609 /* SearchView.swift */; };
 		09E8E5F42512233704B3A4F6 /* LicensePoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */; };
+		0A3760D03332F2FC23F5BCC3 /* InstallPluginFromGitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DD24CE59A14232D46D4665 /* InstallPluginFromGitView.swift */; };
 		0AB4F8101A72D6C81B34D496 /* BuildsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E5BB60BE578603D5B6925 /* BuildsView.swift */; };
 		0BC68220DEF68CF93D468766 /* QualityMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF539B04F8B6390EDFE0643B /* QualityMapping.swift */; };
 		0CD3534A62BFE963B4793311 /* VirtualMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F508C0FBF498EB51BC64EE /* VirtualMember.swift */; };
@@ -53,6 +54,7 @@
 		2E5EA6194F309490D85C7FF9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1164C99171DC47A99F71C0D /* Assets.xcassets */; };
 		2EE7333E8775B1BB8124E0B7 /* Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA65CF7CCFDB01286A0C408 /* Integration.swift */; };
 		32C0A53DAE5CEA63670B57F2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 36656CBAF76FAB0F5ECC7855 /* Alamofire */; };
+		32DCAA417773BE4B603C28D9 /* InstallPluginFromGitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DD24CE59A14232D46D4665 /* InstallPluginFromGitView.swift */; };
 		3366AEE087831CF15004691F /* DashboardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */; };
 		363B3E9588A4895C999757BC /* PackagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C67E4A61ED479E094891F7 /* PackagesView.swift */; };
 		389A90FAD7E4FDA7B8464B92 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73AE1952EFB3C338C7D0771 /* LoginView.swift */; };
@@ -254,6 +256,7 @@
 		1901D688CCAD3DE71AA681AC /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		1C63C47E06CD6C0372C017A2 /* CveLicensePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CveLicensePathTests.swift; sourceTree = "<group>"; };
 		1DB4EEF15843269173A9B772 /* TOTPVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPVerificationView.swift; sourceTree = "<group>"; };
+		26DD24CE59A14232D46D4665 /* InstallPluginFromGitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallPluginFromGitView.swift; sourceTree = "<group>"; };
 		26F832901A43DC98CC288AA4 /* ArtifactSecurityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSecurityView.swift; sourceTree = "<group>"; };
 		28281FCD705C9F9F4DF23AF7 /* Quality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quality.swift; sourceTree = "<group>"; };
 		3412EF9765589F0F5C9613ED /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
@@ -699,6 +702,7 @@
 		F17866B4DADD535323D2A2E4 /* Integration */ = {
 			isa = PBXGroup;
 			children = (
+				26DD24CE59A14232D46D4665 /* InstallPluginFromGitView.swift */,
 				F130C4E4EC403EC23594AE44 /* PeersView.swift */,
 				8F05BA048E8B88FD14314F17 /* PluginsView.swift */,
 				8067728F7917AD61F0DB4037 /* ReplicationView.swift */,
@@ -915,6 +919,7 @@
 				87DFC05DFE36A27A9C5769A6 /* EditRepositorySheet.swift in Sources */,
 				B711A4EF6DF167F16406CBD3 /* GroupsView.swift in Sources */,
 				6D02C2A0C45C6E1D0AA70FE2 /* HealthDashboardView.swift in Sources */,
+				0A3760D03332F2FC23F5BCC3 /* InstallPluginFromGitView.swift in Sources */,
 				2EE7333E8775B1BB8124E0B7 /* Integration.swift in Sources */,
 				634179231AD90932820E8519 /* IntegrationSectionView.swift in Sources */,
 				B7F76BE14A732DCCD7EDF405 /* KeychainManager.swift in Sources */,
@@ -1031,6 +1036,7 @@
 				638F88CF707835320776D7D7 /* EditRepositorySheet.swift in Sources */,
 				0D2124206E78085A90971F0A /* GroupsView.swift in Sources */,
 				7C9F12D37482E704E49A3814 /* HealthDashboardView.swift in Sources */,
+				32DCAA417773BE4B603C28D9 /* InstallPluginFromGitView.swift in Sources */,
 				5E0D22452C4DCD3E0ECCEED2 /* Integration.swift in Sources */,
 				C0067BC56E14F7597CD91596 /* IntegrationSectionView.swift in Sources */,
 				D7AD6E41B44AF34DF7994C57 /* KeychainManager.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -530,6 +530,17 @@ actor APIClient {
         try await request("/api/v1/plugins/\(id)")
     }
 
+    /// Install a plugin from a Git repository (POST /api/v1/plugins/install/git).
+    func installPluginFromGit(url: String, ref: String? = nil) async throws -> PluginInstallResult {
+        let body = InstallFromGitRequest(url: url, ref: ref)
+        return try await request("/api/v1/plugins/install/git", method: "POST", body: body)
+    }
+
+    /// Uninstall a plugin (DELETE /api/v1/plugins/{id}).
+    func uninstallPlugin(id: String) async throws {
+        try await requestVoid("/api/v1/plugins/\(id)", method: "DELETE")
+    }
+
     // MARK: Repository Tree Browse (1.2.1: GET /api/v1/tree)
 
     /// Fetch the repository tree at a given path. Pass an empty path for the root.

--- a/ArtifactKeeper/Sources/Core/Models/Integration.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Integration.swift
@@ -180,3 +180,25 @@ struct Plugin: Codable, Identifiable, Sendable {
 struct PluginListResponse: Codable, Sendable {
     let items: [Plugin]
 }
+
+/// Body for POST /api/v1/plugins/install/git.
+struct InstallFromGitRequest: Encodable {
+    let url: String
+    /// Optional git ref (tag, branch, or commit).
+    let ref: String?
+}
+
+/// Response from a plugin install (POST /api/v1/plugins/install/git).
+struct PluginInstallResult: Codable, Sendable {
+    let pluginId: String
+    let name: String
+    let version: String
+    let formatKey: String
+    let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case name, version, message
+        case pluginId = "plugin_id"
+        case formatKey = "format_key"
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Integration/InstallPluginFromGitView.swift
+++ b/ArtifactKeeper/Sources/Features/Integration/InstallPluginFromGitView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// Sheet for installing a format plugin from a Git repository
+/// (POST /api/v1/plugins/install/git). The operator enters a repository URL and
+/// an optional ref (tag, branch, or commit).
+struct InstallPluginFromGitView: View {
+    /// Called with the install result after a successful install so the caller
+    /// can refresh its list and surface a confirmation.
+    let onInstalled: (PluginInstallResult) async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var url = ""
+    @State private var ref = ""
+    @State private var isInstalling = false
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+
+    private var trimmedURL: String {
+        url.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        Form {
+            Section("Repository") {
+                TextField("Git URL (https://...)", text: $url)
+                    #if os(iOS)
+                    .autocapitalization(.none)
+                    .keyboardType(.URL)
+                    .disableAutocorrection(true)
+                    #endif
+                TextField("Ref (optional: tag, branch, or commit)", text: $ref)
+                    #if os(iOS)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                    #endif
+            }
+
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
+            }
+
+            Section {
+                Button {
+                    Task { await install() }
+                } label: {
+                    if isInstalling {
+                        HStack {
+                            ProgressView().controlSize(.small)
+                            Text("Installing\u{2026}")
+                        }
+                    } else {
+                        Text("Install")
+                    }
+                }
+                .disabled(trimmedURL.isEmpty || isInstalling)
+            }
+        }
+        .navigationTitle("Install from Git")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+                    .disabled(isInstalling)
+            }
+        }
+    }
+
+    private func install() async {
+        isInstalling = true
+        errorMessage = nil
+        defer { isInstalling = false }
+        let trimmedRef = ref.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            let result = try await apiClient.installPluginFromGit(
+                url: trimmedURL,
+                ref: trimmedRef.isEmpty ? nil : trimmedRef
+            )
+            await onInstalled(result)
+            dismiss()
+        } catch {
+            errorMessage = "Install failed: \(error.localizedDescription)"
+        }
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Integration/PluginsView.swift
+++ b/ArtifactKeeper/Sources/Features/Integration/PluginsView.swift
@@ -1,14 +1,16 @@
 import SwiftUI
 
-/// Lists installed WASM format plugins and supports enable/disable/reload.
-/// Installation (upload/git/local/zip), uninstall and config authoring are
-/// deferred: they are deep-authoring/upload flows better suited to the web UI.
+/// Lists installed WASM format plugins and supports enable/disable/reload,
+/// install from a Git URL, and uninstall (with confirmation).
+/// Local/zip uploads and config authoring stay deferred: they are upload /
+/// deep-authoring flows better suited to the web UI.
 struct PluginsView: View {
     @State private var plugins: [Plugin] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
     @State private var mutatingPluginId: String?
     @State private var actionMessage: (success: Bool, text: String)?
+    @State private var showingInstall = false
 
     private let apiClient = APIClient.shared
 
@@ -48,7 +50,8 @@ struct PluginsView: View {
                                 listPlugin: plugin,
                                 isMutating: mutatingPluginId == plugin.id,
                                 onToggle: { await toggle(plugin) },
-                                onReload: { await reload(plugin) }
+                                onReload: { await reload(plugin) },
+                                onUninstall: { await uninstall(plugin) }
                             )
                         } label: {
                             PluginRow(plugin: plugin)
@@ -60,6 +63,23 @@ struct PluginsView: View {
         }
         .refreshable { await loadPlugins() }
         .task { await loadPlugins() }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingInstall = true
+                } label: {
+                    Label("Install from Git", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showingInstall) {
+            NavigationStack {
+                InstallPluginFromGitView { result in
+                    actionMessage = (true, "Installed \(result.name) \(result.version).")
+                    await loadPlugins()
+                }
+            }
+        }
     }
 
     private func loadPlugins() async {
@@ -104,6 +124,18 @@ struct PluginsView: View {
             await loadPlugins()
         } catch {
             actionMessage = (false, "Failed to reload \(plugin.displayName): \(error.localizedDescription)")
+        }
+    }
+
+    private func uninstall(_ plugin: Plugin) async {
+        mutatingPluginId = plugin.id
+        defer { mutatingPluginId = nil }
+        do {
+            try await apiClient.uninstallPlugin(id: plugin.id)
+            actionMessage = (true, "\(plugin.displayName) uninstalled.")
+            await loadPlugins()
+        } catch {
+            actionMessage = (false, "Failed to uninstall \(plugin.displayName): \(error.localizedDescription)")
         }
     }
 }
@@ -157,9 +189,13 @@ struct PluginDetailView: View {
     let isMutating: Bool
     let onToggle: () async -> Void
     let onReload: () async -> Void
+    let onUninstall: () async -> Void
 
     @State private var fetched: Plugin?
     @State private var loadError: String?
+    @State private var showingUninstallConfirm = false
+
+    @Environment(\.dismiss) private var dismiss
 
     private let apiClient = APIClient.shared
 
@@ -221,6 +257,15 @@ struct PluginDetailView: View {
                 }
                 .disabled(isMutating)
             }
+
+            Section {
+                Button(role: .destructive) {
+                    showingUninstallConfirm = true
+                } label: {
+                    Label("Uninstall", systemImage: "trash")
+                }
+                .disabled(isMutating)
+            }
         }
         .navigationTitle(plugin.displayName)
         #if os(iOS)
@@ -228,6 +273,21 @@ struct PluginDetailView: View {
         #endif
         .task { await loadDetail() }
         .refreshable { await loadDetail() }
+        .confirmationDialog(
+            "Uninstall \(plugin.displayName)?",
+            isPresented: $showingUninstallConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Uninstall", role: .destructive) {
+                Task {
+                    await onUninstall()
+                    dismiss()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the plugin and its format handler from the server. This cannot be undone.")
+        }
     }
 
     private func loadDetail() async {

--- a/ArtifactKeeper/Tests/PluginPathTests.swift
+++ b/ArtifactKeeper/Tests/PluginPathTests.swift
@@ -104,4 +104,42 @@ struct PluginPathTests {
 
         #expect(log.contains(method: "POST", path: "/api/v1/plugins/plg-1/reload"))
     }
+
+    // The two tests below drive the real production methods (not a hand-built
+    // request) so the path/method assertions guard the actual install/uninstall
+    // call sites used by PluginsView.
+
+    @Test func installFromGitHitsGitInstallPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PluginCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return pluginOk(request.url!, """
+            {"plugin_id":"plg-9","name":"Unity Format","version":"1.2.0",
+             "format_key":"unity","message":"installed"}
+            """)
+        }
+
+        let result = try await mock.client.installPluginFromGit(
+            url: "https://github.com/example/unity-plugin.git",
+            ref: "v1.2.0"
+        )
+
+        #expect(log.contains(method: "POST", path: "/api/v1/plugins/install/git"))
+        #expect(result.pluginId == "plg-9")
+        #expect(result.formatKey == "unity")
+    }
+
+    @Test func uninstallPluginHitsPluginByIdPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PluginCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return pluginOk(request.url!, "")
+        }
+
+        try await mock.client.uninstallPlugin(id: "plg-7")
+
+        #expect(log.contains(method: "DELETE", path: "/api/v1/plugins/plg-7"))
+    }
 }


### PR DESCRIPTION
## Summary
Extends the Integration Plugins screen with the two remaining lifecycle ops.

**Install from Git**: a toolbar button opens a sheet where the operator enters a repository URL and an optional ref (tag, branch, or commit), then installs via `POST /api/v1/plugins/install/git` and refreshes the list with a confirmation message.

**Uninstall**: the plugin detail screen gains a destructive Uninstall action behind a confirmation dialog; on confirm it calls `DELETE /api/v1/plugins/{id}` and dismisses back to the list.

Raw-request style matching the existing PluginsView enable/disable/reload calls, with `InstallFromGitRequest` / `PluginInstallResult` models in `Integration.swift` and `installPluginFromGit` / `uninstallPlugin` on `APIClient`.

### Resolved ops
- `install_from_git` (POST /api/v1/plugins/install/git)
- `uninstall_plugin` (DELETE /api/v1/plugins/{id})

### Deferred
- `install_from_local` / `install_from_zip` / `install_plugin` -- file upload flows, better suited to the web UI
- `get_plugin_config` / `update_plugin_config` -- config authoring

Closes #73
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Two path-pinning tests in `PluginPathTests` drive the real `installPluginFromGit` and `uninstallPlugin` methods through a per-instance `MockSession` and assert `POST /api/v1/plugins/install/git` and `DELETE /api/v1/plugins/plg-7` respectively. Full suite green: 492 tests.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements