### PR TITLE
feat(ios): CVE detail with status change (update_cve_status)

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		435F616F353CDF139BE4859E /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F289613B7B5E1B85C3F9E832 /* ArtifactDetailView.swift */; };
 		43CD93CC42B93AE1999FA8B9 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84212AD84A94810D2C23339 /* AuthManagerTests.swift */; };
 		45EF793A77005F62C4263D1E /* WebhookPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D532EA4136F5C5CF5548AE /* WebhookPathTests.swift */; };
+		463C7D9720887BA8C9449710 /* CveHistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B8C85944DE179E8F1750EF /* CveHistoryDetailView.swift */; };
 		475F7C0CA9365AB11D952814 /* ReplicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8067728F7917AD61F0DB4037 /* ReplicationView.swift */; };
 		47DFA7F8B01E5A21906642A2 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DDB4F8B15C1FB99A2843 /* Package.swift */; };
 		4A9D08A77DCBD1954B4CB334 /* Quality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28281FCD705C9F9F4DF23AF7 /* Quality.swift */; };
@@ -112,6 +113,7 @@
 		78A16F7733A939DF72627EAA /* OperationsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6A94422BAD7B966077C0D9 /* OperationsSectionView.swift */; };
 		7926AACBA3FC6E057D5340FE /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C4236474392052DD29004F /* DashboardView.swift */; };
 		797AE3D1C3726C2AAA195E4D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3E2D65A21BA60C8957EE36 /* ContentView.swift */; };
+		7A98B50F5AFC9B536392E6AB /* CveHistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B8C85944DE179E8F1750EF /* CveHistoryDetailView.swift */; };
 		7B983BDEC8F0E8548B9E7E5E /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1901D688CCAD3DE71AA681AC /* APIClientTests.swift */; };
 		7C9F12D37482E704E49A3814 /* HealthDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AB45AA08A0DE4EA42BC041 /* HealthDashboardView.swift */; };
 		7D990B45FF3ECE2858347141 /* CveLicensePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63C47E06CD6C0372C017A2 /* CveLicensePathTests.swift */; };
@@ -353,6 +355,7 @@
 		F8761FACD0287EF99C0A1E50 /* UsersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersView.swift; sourceTree = "<group>"; };
 		F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityDispatchTests.swift; sourceTree = "<group>"; };
 		F9415E01C2D644848CDBB4D0 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		F9B8C85944DE179E8F1750EF /* CveHistoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CveHistoryDetailView.swift; sourceTree = "<group>"; };
 		FCA65CF7CCFDB01286A0C408 /* Integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Integration.swift; sourceTree = "<group>"; };
 		FD29BEA4F2708262CE34F2E3 /* SecuritySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuritySectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -461,6 +464,7 @@
 			isa = PBXGroup;
 			children = (
 				26F832901A43DC98CC288AA4 /* ArtifactSecurityView.swift */,
+				F9B8C85944DE179E8F1750EF /* CveHistoryDetailView.swift */,
 				50DB58698E8E2409CAFE93AA /* CveHistoryView.swift */,
 				59106973EB99FD9424D44224 /* DtDashboardView.swift */,
 				07736CEE9959BC4566162E12 /* DtProjectsView.swift */,
@@ -911,6 +915,7 @@
 				EBBA4D16B78FD192D954563C /* BuildsView.swift in Sources */,
 				E4618623F8473A8661B7CC6F /* ChangePasswordView.swift in Sources */,
 				797AE3D1C3726C2AAA195E4D /* ContentView.swift in Sources */,
+				7A98B50F5AFC9B536392E6AB /* CveHistoryDetailView.swift in Sources */,
 				941BDA39A576A8603BE0E7F7 /* CveHistoryView.swift in Sources */,
 				7926AACBA3FC6E057D5340FE /* DashboardView.swift in Sources */,
 				0050E6CD740666B06CF4F1F6 /* DependencyTrack.swift in Sources */,
@@ -1028,6 +1033,7 @@
 				0AB4F8101A72D6C81B34D496 /* BuildsView.swift in Sources */,
 				238DBF144A2302C11DE50388 /* ChangePasswordView.swift in Sources */,
 				EA935E6E499F8A518FCBA8C3 /* ContentView.swift in Sources */,
+				463C7D9720887BA8C9449710 /* CveHistoryDetailView.swift in Sources */,
 				19F5B56288A694863407E57B /* CveHistoryView.swift in Sources */,
 				04E9EC2157EA947C8B9FE159 /* DashboardView.swift in Sources */,
 				D36FF1BE98A8940CC8E38C27 /* DependencyTrack.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -892,6 +892,24 @@ actor APIClient {
         return try await request("/api/v1/sbom/cve/history/\(encoded)")
     }
 
+    /// Set the triage status of a CVE on an artifact, returning the updated record
+    /// (POST /api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id}).
+    func updateCveStatusByArtifactCve(
+        artifactId: String,
+        cveId: String,
+        status: String,
+        reason: String? = nil
+    ) async throws -> CveHistoryEntry {
+        let encodedArtifact = artifactId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? artifactId
+        let encodedCve = cveId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? cveId
+        let body = UpdateCveStatusRequest(status: status, reason: reason)
+        return try await request(
+            "/api/v1/sbom/cve/status/by-artifact/\(encodedArtifact)/by-cve/\(encodedCve)",
+            method: "POST",
+            body: body
+        )
+    }
+
     /// Check a set of licenses against policy (POST /api/v1/sbom/check-compliance).
     func checkLicenseCompliance(licenses: [String], repositoryId: String? = nil) async throws -> LicenseCheckResult {
         let body = CheckLicenseComplianceRequest(licenses: licenses, repositoryId: repositoryId)

--- a/ArtifactKeeper/Sources/Core/Models/Sbom.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Sbom.swift
@@ -282,6 +282,32 @@ struct CheckLicenseComplianceRequest: Encodable {
     }
 }
 
+/// Body for POST /api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id}.
+/// Matches the v1.2.1 UpdateCveStatusRequest schema: required status, optional reason.
+struct UpdateCveStatusRequest: Encodable {
+    let status: String
+    let reason: String?
+}
+
+/// UI affordances for the existing CveStatus wire enum: the picker options the
+/// operator can set on a history record, plus human labels. The raw values are
+/// the wire values the backend accepts for UpdateCveStatusRequest.status.
+extension CveStatus: CaseIterable, Identifiable {
+    static var allCases: [CveStatus] { [.open, .acknowledged, .falsePositive, .fixed] }
+
+    var id: String { rawValue }
+
+    /// Human label for the picker and status badges.
+    var label: String {
+        switch self {
+        case .open: return "Open"
+        case .acknowledged: return "Acknowledged"
+        case .falsePositive: return "False positive"
+        case .fixed: return "Fixed"
+        }
+    }
+}
+
 // MARK: - AnyCodable helper for dynamic JSON
 
 struct AnyCodable: Codable, @unchecked Sendable {

--- a/ArtifactKeeper/Sources/Features/Security/CveHistoryDetailView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/CveHistoryDetailView.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+/// Detail for a single CVE history record. Opened from a row in CveHistoryView.
+///
+/// On appearance it re-fetches the record by id via APIClient.getCveHistory(id:)
+/// (GET /api/v1/sbom/cve/history/{id}) rather than reusing the list row, so the
+/// detail always shows the current server state. The operator can change the
+/// triage status, which posts to
+/// /api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id} and updates
+/// the displayed record with the response.
+struct CveHistoryDetailView: View {
+    /// The id of the history record to load. The artifact id and CVE id used for
+    /// the status mutation come from the fetched record, not from the list row.
+    let entryId: String
+
+    @State private var entry: CveHistoryEntry?
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    @State private var selectedStatus: CveStatus = .open
+    @State private var reason = ""
+    @State private var isSaving = false
+    @State private var statusAlert: StatusAlert?
+
+    private let apiClient = APIClient.shared
+
+    /// Result of a status-change attempt, surfaced as an alert.
+    private struct StatusAlert: Identifiable {
+        let id = UUID()
+        let title: String
+        let message: String
+    }
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading\u{2026}")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let loadError {
+                ContentUnavailableView {
+                    Label("Could Not Load Record", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(loadError)
+                } actions: {
+                    Button("Retry") { Task { await load() } }
+                        .buttonStyle(.borderedProminent)
+                }
+            } else if let entry {
+                detail(for: entry)
+            }
+        }
+        .navigationTitle("CVE Detail")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { await load() }
+        .alert(item: $statusAlert) { alert in
+            Alert(
+                title: Text(alert.title),
+                message: Text(alert.message),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func detail(for entry: CveHistoryEntry) -> some View {
+        Form {
+            Section("Vulnerability") {
+                LabeledContent("CVE") {
+                    Link(entry.cveId, destination: URL(string: "https://nvd.nist.gov/vuln/detail/\(entry.cveId)")!)
+                }
+                if let severity = entry.severity {
+                    LabeledContent("Severity", value: severity.capitalized)
+                }
+                if let score = entry.cvssScore {
+                    LabeledContent("CVSS", value: String(format: "%.1f", score))
+                }
+                LabeledContent("Current status", value: statusLabel(entry.status))
+            }
+
+            Section("Affected") {
+                if let component = entry.affectedComponent {
+                    LabeledContent("Component", value: component)
+                }
+                if let version = entry.affectedVersion {
+                    LabeledContent("Version", value: version)
+                }
+                if let fixed = entry.fixedVersion, !fixed.isEmpty {
+                    LabeledContent("Fixed in", value: fixed)
+                }
+            }
+
+            Section("Timeline") {
+                LabeledContent("First detected", value: formattedDate(entry.firstDetectedAt))
+                LabeledContent("Last detected", value: formattedDate(entry.lastDetectedAt))
+                if let ackBy = entry.acknowledgedBy {
+                    LabeledContent("Acknowledged by", value: ackBy)
+                }
+                if let ackReason = entry.acknowledgedReason, !ackReason.isEmpty {
+                    LabeledContent("Reason", value: ackReason)
+                }
+            }
+
+            Section("Set status") {
+                Picker("Status", selection: $selectedStatus) {
+                    ForEach(CveStatus.allCases) { status in
+                        Text(status.label).tag(status)
+                    }
+                }
+                TextField("Reason (optional)", text: $reason, axis: .vertical)
+                    .lineLimit(1...3)
+                Button {
+                    Task { await applyStatus(for: entry) }
+                } label: {
+                    if isSaving {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text("Update status")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isSaving || selectedStatus.rawValue == entry.status)
+            }
+        }
+        #if os(iOS)
+        .formStyle(.grouped)
+        #endif
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+        do {
+            let fetched = try await apiClient.getCveHistory(id: entryId)
+            entry = fetched
+            selectedStatus = CveStatus(rawValue: fetched.status) ?? .open
+        } catch {
+            entry = nil
+            loadError = "Could not load this record: \(error.localizedDescription)"
+        }
+    }
+
+    private func applyStatus(for entry: CveHistoryEntry) async {
+        isSaving = true
+        defer { isSaving = false }
+        let trimmedReason = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            let updated = try await apiClient.updateCveStatusByArtifactCve(
+                artifactId: entry.artifactId,
+                cveId: entry.cveId,
+                status: selectedStatus.rawValue,
+                reason: trimmedReason.isEmpty ? nil : trimmedReason
+            )
+            self.entry = updated
+            selectedStatus = CveStatus(rawValue: updated.status) ?? selectedStatus
+            statusAlert = StatusAlert(
+                title: "Status updated",
+                message: "\(updated.cveId) is now \(statusLabel(updated.status))."
+            )
+        } catch {
+            // Non-destructive: keep the displayed record as-is and report the failure.
+            statusAlert = StatusAlert(
+                title: "Update failed",
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    private func statusLabel(_ status: String) -> String {
+        CveStatus(rawValue: status)?.label ?? status.capitalized
+    }
+
+    private func formattedDate(_ dateString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: dateString) {
+            let display = DateFormatter()
+            display.dateStyle = .medium
+            display.timeStyle = .short
+            return display.string(from: date)
+        }
+        return dateString
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Security/CveHistoryView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/CveHistoryView.swift
@@ -94,7 +94,11 @@ struct CveHistoryView: View {
         } else {
             List {
                 ForEach(entries) { entry in
-                    CveHistoryEntryRow(entry: entry)
+                    NavigationLink {
+                        CveHistoryDetailView(entryId: entry.id)
+                    } label: {
+                        CveHistoryEntryRow(entry: entry)
+                    }
                 }
             }
             .listStyle(.plain)

--- a/ArtifactKeeper/Tests/CveLicensePathTests.swift
+++ b/ArtifactKeeper/Tests/CveLicensePathTests.swift
@@ -69,6 +69,52 @@ struct CveLicensePathTests {
         #expect(entry.cveId == "CVE-2024-1234")
     }
 
+    @Test func updateCveStatusTargetsByArtifactByCvePath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let recorder = PathRecorder()
+        let methodBox = MethodRecorder()
+        let bodyBox = BodyRecorder()
+        mock.handler = { request in
+            recorder.record(request.url!.path)
+            methodBox.record(request.httpMethod ?? "")
+            // URLProtocol drops httpBody for streamed bodies; read httpBodyStream too.
+            if let data = request.httpBody {
+                bodyBox.record(data)
+            } else if let stream = request.httpBodyStream {
+                bodyBox.record(BodyRecorder.drain(stream))
+            }
+            // Echo a CveHistoryEntry with the new status so the method decodes.
+            return self.okResponse(request.url!, """
+            {
+              "id": "hist-9",
+              "artifact_id": "art-1",
+              "cve_id": "CVE-2024-1234",
+              "first_detected_at": "2024-01-01T00:00:00Z",
+              "last_detected_at": "2024-01-02T00:00:00Z",
+              "status": "acknowledged",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-02T00:00:00Z"
+            }
+            """)
+        }
+
+        let updated = try await mock.client.updateCveStatusByArtifactCve(
+            artifactId: "art-1",
+            cveId: "CVE-2024-1234",
+            status: "acknowledged",
+            reason: "Mitigated by config"
+        )
+
+        #expect(recorder.paths.contains("/api/v1/sbom/cve/status/by-artifact/art-1/by-cve/CVE-2024-1234"))
+        #expect(methodBox.methods.contains("POST"))
+        #expect(updated.status == "acknowledged")
+
+        let sentBody = try #require(bodyBox.data)
+        let decoded = try JSONSerialization.jsonObject(with: sentBody) as? [String: Any]
+        #expect(decoded?["status"] as? String == "acknowledged")
+        #expect(decoded?["reason"] as? String == "Mitigated by config")
+    }
+
     @Test func checkLicenseComplianceTargetsCheckCompliancePath() async throws {
         let mock = MockSession(baseURL: "https://test-api.example.com")
         let recorder = PathRecorder()
@@ -100,5 +146,34 @@ final class MethodRecorder: @unchecked Sendable {
     var methods: [String] {
         lock.lock(); defer { lock.unlock() }
         return _methods
+    }
+}
+
+/// Captures the request body bytes a method sent, draining a stream if needed.
+final class BodyRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _data: Data?
+    func record(_ data: Data) {
+        lock.lock(); defer { lock.unlock() }
+        _data = data
+    }
+    var data: Data? {
+        lock.lock(); defer { lock.unlock() }
+        return _data
+    }
+
+    /// Reads an open or unopened input stream to completion.
+    static func drain(_ stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var result = Data()
+        let size = 4096
+        var buffer = [UInt8](repeating: 0, count: size)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: size)
+            if read <= 0 { break }
+            result.append(buffer, count: read)
+        }
+        return result
     }
 }


### PR DESCRIPTION
## Summary
Closes a v1.2.1 parity gap with the Android app: the Security section's CVEs tab now drills into a CVE detail screen that supports changing triage status.

- CVE history rows in `CveHistoryView` are now tappable into a new `CveHistoryDetailView` (NavigationLink; the view already lives inside the Security `NavigationStack`).
- On `.task`, the detail re-fetches the single record by id via `APIClient.getCveHistory(id:)` (GET `/api/v1/sbom/cve/history/{id}`) and renders the fetched value rather than reusing the list row. This wires `get_cve_history` to real UI for the first time (it was API-only before).
- A "Set status" control (Picker: open / acknowledged / false_positive / fixed, plus an optional reason field) calls a new `APIClient.updateCveStatusByArtifactCve(artifactId:cveId:status:reason:)` method, POST `/api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id}`. The `artifact_id` and `cve_id` come from the fetched record at runtime.
- App-owned `UpdateCveStatusRequest` model matches the v1.2.1 schema exactly (required `status`, optional `reason`); the response decodes back into `CveHistoryEntry`. The existing `CveStatus` wire enum is reused (extended with picker affordances) rather than duplicated.

Native UX: loading and error-with-retry on the detail fetch; a successful status change updates the displayed record, and a failure shows a non-destructive alert leaving the record untouched.

House pattern followed: raw `APIClient.request()` + app-owned Codable models, matching the existing `CveHistoryView`/`SbomView` raw-request style.

Resolved parity rows: `get_cve_history` (now UI-wired), `update_cve_status_by_artifact_cve` (new client method + UI).

Closes #75
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New path-pinning dispatch test `updateCveStatusTargetsByArtifactByCvePath` drives the real `updateCveStatusByArtifactCve` method through a per-instance `MockSession` and asserts the request path, POST method, and the `status`+`reason` body. `get_cve_history` was already pinned by `getCveHistoryTargetsHistoryByIdPath`. Full `xcodebuild test` (macOS) is green.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [x] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements
- [ ] N/A - no UI changes