### PR TITLE
feat(ios): peer detail, identity, and connections (read)

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		B27985BB328A3F0ACCEF2EB5 /* LicensePoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */; };
 		B2BDDB70803CC764E1147668 /* RepoSecurityConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */; };
 		B42C3893B88FDD3E8D354DB5 /* DtProjectsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07736CEE9959BC4566162E12 /* DtProjectsView.swift */; };
+		B4D132E4714A2FD2223C12BA /* PeerPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841ACC5D23588C4D5941ED3 /* PeerPathTests.swift */; };
 		B4D6FB0A72BFCD4B4251E2E2 /* ArtifactsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E44194ACD18BA49B67189B /* ArtifactsSectionView.swift */; };
 		B516A827540A1DDE26F2B9BA /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = F1F1A51E9222F8A1C1F5C1EB /* Dependencies */; };
 		B535272FD68109CDCE673AFC /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = A0A50A1985B1B97F68A946DA /* Alamofire */; };
@@ -217,6 +218,7 @@
 		F37EAD999EEE9694758BBE8D /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15E45652EBB4DD2505127F /* WelcomeView.swift */; };
 		F5CE55686817D88933AC4AC1 /* AuthManagerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */; };
 		F790A545605AFA178BEEA506 /* WebhooksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8063DEF3B0228C26496797B7 /* WebhooksView.swift */; };
+		F7AA91D695276F372E1B9AAD /* PeerPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841ACC5D23588C4D5941ED3 /* PeerPathTests.swift */; };
 		FABB8132DF5CEA339A9B769A /* APIPathRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */; };
 		FB1F242DC31148C08DA16397 /* APIClientNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */; };
 		FBB9BAC6869454925F45B080 /* ArtifactDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A41A1778E2034F039852708 /* ArtifactDetailTests.swift */; };
@@ -251,6 +253,7 @@
 		113DC09E3B0845FAD9BDA8F6 /* SetupInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupInstructionsView.swift; sourceTree = "<group>"; };
 		1464BFA481535D3C3B4F4CC5 /* GroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsView.swift; sourceTree = "<group>"; };
 		155377690C14964BAFBAF481 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		1841ACC5D23588C4D5941ED3 /* PeerPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerPathTests.swift; sourceTree = "<group>"; };
 		1901D688CCAD3DE71AA681AC /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		1C63C47E06CD6C0372C017A2 /* CveLicensePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CveLicensePathTests.swift; sourceTree = "<group>"; };
 		1DB4EEF15843269173A9B772 /* TOTPVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPVerificationView.swift; sourceTree = "<group>"; };
@@ -429,6 +432,7 @@
 				888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */,
 				AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */,
 				942CFADFFB28FA592F32CAB1 /* ModelTests.swift */,
+				1841ACC5D23588C4D5941ED3 /* PeerPathTests.swift */,
 				4147C420ECCBB9137917722C /* PluginPathTests.swift */,
 				8211F9D04C3BF74AB42324D9 /* QualityMappingTests.swift */,
 				435C7C6ACC4028C205301D14 /* RepositoryTreeTests.swift */,
@@ -873,6 +877,7 @@
 				99C3358F603E8600CA038F75 /* DashboardViewTests.swift in Sources */,
 				ECE469E91BEE0E35EB258F98 /* KeychainManagerTests.swift in Sources */,
 				FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */,
+				B4D132E4714A2FD2223C12BA /* PeerPathTests.swift in Sources */,
 				293314A1B0346F707F5B3CE4 /* PluginPathTests.swift in Sources */,
 				E15A1D5EA6FDA4D8DAF42CF7 /* QualityMappingTests.swift in Sources */,
 				1A02AD83B2F212120BFC892A /* RepositoryTreeTests.swift in Sources */,
@@ -989,6 +994,7 @@
 				3366AEE087831CF15004691F /* DashboardViewTests.swift in Sources */,
 				6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */,
 				83D01D48B7B7C3739E1344B3 /* ModelTests.swift in Sources */,
+				F7AA91D695276F372E1B9AAD /* PeerPathTests.swift in Sources */,
 				B18AAE17086834FBB57455D9 /* PluginPathTests.swift in Sources */,
 				868F52C07277B589BE29205D /* QualityMappingTests.swift in Sources */,
 				4BA74F65F09BD28BC25CC705 /* RepositoryTreeTests.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -530,6 +530,23 @@ actor APIClient {
         try await request("/api/v1/plugins/\(id)")
     }
 
+    // MARK: Peers / Federation (Integration)
+
+    /// This instance's own federation identity (GET /api/v1/peers/identity).
+    func getPeerIdentity() async throws -> PeerIdentity {
+        try await request("/api/v1/peers/identity")
+    }
+
+    /// Fetch a single peer by id (GET /api/v1/peers/{id}).
+    func getPeer(id: String) async throws -> Peer {
+        try await request("/api/v1/peers/\(id)")
+    }
+
+    /// List a peer's known connections (GET /api/v1/peers/{id}/connections).
+    func listPeerConnections(id: String) async throws -> [PeerConnection] {
+        try await request("/api/v1/peers/\(id)/connections")
+    }
+
     // MARK: Repository Tree Browse (1.2.1: GET /api/v1/tree)
 
     /// Fetch the repository tree at a given path. Pass an empty path for the root.

--- a/ArtifactKeeper/Sources/Core/Models/Integration.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Integration.swift
@@ -34,6 +34,19 @@ struct PeerListResponse: Codable, Sendable {
     let total: Int
 }
 
+/// This instance's own federation identity (GET /api/v1/peers/identity).
+struct PeerIdentity: Codable, Sendable {
+    let peerId: String
+    let name: String
+    let endpointUrl: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case peerId = "peer_id"
+        case endpointUrl = "endpoint_url"
+    }
+}
+
 struct PeerConnection: Codable, Identifiable, Sendable {
     let id: String
     let targetPeerId: String

--- a/ArtifactKeeper/Sources/Features/Integration/PeersView.swift
+++ b/ArtifactKeeper/Sources/Features/Integration/PeersView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PeersView: View {
     @State private var peers: [Peer] = []
+    @State private var identity: PeerIdentity?
     @State private var isLoading = true
     @State private var errorMessage: String?
     @State private var showingRegisterPeer = false
@@ -30,13 +31,28 @@ struct PeersView: View {
                         Spacer()
                     } else {
                         List {
-                            ForEach(peers) { peer in
-                                PeerRow(peer: peer)
+                            if let identity {
+                                Section("This Instance") {
+                                    LabeledContent("Name", value: identity.name)
+                                    LabeledContent("Peer ID", value: identity.peerId)
+                                    LabeledContent("Endpoint", value: identity.endpointUrl)
+                                        .lineLimit(1)
+                                }
                             }
-                            .onDelete { indexSet in
-                                Task {
-                                    for index in indexSet {
-                                        await deletePeer(peers[index])
+
+                            Section("Peers") {
+                                ForEach(peers) { peer in
+                                    NavigationLink {
+                                        PeerDetailView(listPeer: peer)
+                                    } label: {
+                                        PeerRow(peer: peer)
+                                    }
+                                }
+                                .onDelete { indexSet in
+                                    Task {
+                                        for index in indexSet {
+                                            await deletePeer(peers[index])
+                                        }
                                     }
                                 }
                             }
@@ -90,6 +106,8 @@ struct PeersView: View {
                 errorMessage = "Could not load peers. This feature may not be available on your server."
             }
         }
+        // Identity is best-effort: a failure here should not blank the peer list.
+        identity = try? await apiClient.getPeerIdentity()
         isLoading = false
     }
 
@@ -253,5 +271,112 @@ struct RegisterPeerView: View {
             errorMessage = "Failed to register peer: \(error.localizedDescription)"
         }
         isSaving = false
+    }
+}
+
+// MARK: - Peer Detail
+
+/// Peer detail with a freshly fetched record (GET /api/v1/peers/{id}) and the
+/// peer's connection list (GET /api/v1/peers/{id}/connections).
+struct PeerDetailView: View {
+    let listPeer: Peer
+
+    @State private var fetched: Peer?
+    @State private var connections: [PeerConnection] = []
+    @State private var loadError: String?
+
+    private let apiClient = APIClient.shared
+
+    /// Freshest peer: the by-id fetch if it succeeded, else the list value.
+    private var peer: Peer { fetched ?? listPeer }
+
+    var body: some View {
+        List {
+            if let loadError {
+                Section {
+                    Label(loadError, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Peer") {
+                LabeledContent("Name", value: peer.name)
+                LabeledContent("Status", value: peer.status.capitalized)
+                LabeledContent("Endpoint", value: peer.endpointUrl).lineLimit(1)
+                if let region = peer.region, !region.isEmpty {
+                    LabeledContent("Region", value: region)
+                }
+                LabeledContent("Cache", value: "\(Int(peer.cacheUsagePercent))% used")
+            }
+
+            Section("Lifecycle") {
+                if let heartbeat = peer.lastHeartbeatAt, !heartbeat.isEmpty {
+                    LabeledContent("Last Heartbeat", value: heartbeat)
+                }
+                if let sync = peer.lastSyncAt, !sync.isEmpty {
+                    LabeledContent("Last Sync", value: sync)
+                }
+                LabeledContent("Registered", value: peer.createdAt)
+            }
+
+            Section("Connections (\(connections.count))") {
+                if connections.isEmpty {
+                    Text("No connections recorded.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(connections) { connection in
+                        PeerConnectionRow(connection: connection)
+                    }
+                }
+            }
+        }
+        .navigationTitle(peer.name)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { await load() }
+        .refreshable { await load() }
+    }
+
+    private func load() async {
+        do {
+            fetched = try await apiClient.getPeer(id: listPeer.id)
+            loadError = nil
+        } catch {
+            loadError = "Showing cached details; could not refresh: \(error.localizedDescription)"
+        }
+        // Connections are best-effort and shown separately from the peer record.
+        connections = (try? await apiClient.listPeerConnections(id: listPeer.id)) ?? []
+    }
+}
+
+struct PeerConnectionRow: View {
+    let connection: PeerConnection
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(connection.targetPeerId)
+                    .font(.subheadline.weight(.medium))
+                    .lineLimit(1)
+                Spacer()
+                Text(connection.status.capitalized)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 12) {
+                if let latency = connection.latencyMs {
+                    Label("\(latency) ms", systemImage: "timer")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Label("\(connection.sharedArtifactsCount) artifacts", systemImage: "shippingbox")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
     }
 }

--- a/ArtifactKeeper/Tests/PeerPathTests.swift
+++ b/ArtifactKeeper/Tests/PeerPathTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+@testable import ArtifactKeeper
+
+// Path-pinning tests for the peer detail / identity / connections endpoints used
+// by PeersView and PeerDetailView. Each test drives the real APIClient method
+// (not a hand-built URL) against a MockSession (per-test isolated handler,
+// defined in APIClientNetworkTests.swift) and asserts the exact 1.2.1 path and
+// method. Each test owns its MockSession, so the suite is parallel-safe.
+
+private func peerOk(_ url: URL, _ body: String, status: Int = 200) -> (HTTPURLResponse, Data) {
+    let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+    return (response, Data(body.utf8))
+}
+
+private final class PeerCallLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [(method: String, path: String)] = []
+    func add(_ method: String, _ path: String) {
+        lock.lock(); values.append((method, path)); lock.unlock()
+    }
+    func contains(method: String, path: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return values.contains { $0.method == method && $0.path == path }
+    }
+}
+
+private let peerJSON = """
+{"id":"peer-1","name":"East","endpoint_url":"https://east.example.com","status":"online",
+ "region":"us-east","cache_size_bytes":1000,"cache_used_bytes":500,"cache_usage_percent":50.0,
+ "last_heartbeat_at":null,"last_sync_at":null,"created_at":"2026-06-23T00:00:00Z",
+ "api_key":"k","is_local":false}
+"""
+
+@Suite("Peer Path Tests")
+struct PeerPathTests {
+
+    @Test func getPeerIdentityHitsIdentityPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PeerCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return peerOk(request.url!, #"{"peer_id":"p-1","name":"Local","endpoint_url":"https://local.example.com"}"#)
+        }
+
+        _ = try await mock.client.getPeerIdentity()
+
+        #expect(log.contains(method: "GET", path: "/api/v1/peers/identity"))
+    }
+
+    @Test func getPeerHitsPeerIdPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PeerCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return peerOk(request.url!, peerJSON)
+        }
+
+        _ = try await mock.client.getPeer(id: "peer-1")
+
+        #expect(log.contains(method: "GET", path: "/api/v1/peers/peer-1"))
+    }
+
+    @Test func listPeerConnectionsHitsConnectionsPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let log = PeerCallLog()
+        mock.handler = { request in
+            log.add(request.httpMethod ?? "", request.url!.path)
+            return peerOk(request.url!, "[]")
+        }
+
+        _ = try await mock.client.listPeerConnections(id: "peer-1")
+
+        #expect(log.contains(method: "GET", path: "/api/v1/peers/peer-1/connections"))
+    }
+}


### PR DESCRIPTION
## Summary
Adds the peer read surface to Integration > Peers. `PeersView` already lists/registers/unregisters peers; this adds detail, identity, and connections.

Endpoints wired (raw `APIClient.request` via real methods, app-owned models):
- GET `/api/v1/peers/{id}` (`get_peer`) -> `PeerDetailView` fetches by id on `.task` (falls back to the list value while loading / on error)
- GET `/api/v1/peers/identity` (`get_identity`) -> "This Instance" section in `PeersView`
- GET `/api/v1/peers/{id}/connections` (`list_peer_connections`) -> connections list on the detail screen

New `APIClient.getPeer(id:)`, `getPeerIdentity()`, `listPeerConnections(id:)`. New `PeerIdentity` model; reuses the existing `Peer` and `PeerConnection` models (the latter already matched `PeerResponse`).

Path-pinning tests drive the real APIClient methods (runtime-id paths, not hand-built URLs).

### Deferred (noted in #77)
Machine-protocol / destructive / authoring, deferred to a later peers PR or the web UI:
- `probe_peer` (requires a client-measured latency body), `mark_unreachable` (target connection signal), `discover_peers`, `update_network_profile`
- repo assignments + sync (`get_assigned_repos`, `trigger_sync`, `get_sync_tasks`, ...) -> next peers PR
- all `transfer/*` and `chunks/*` ops (chunk-level transfer protocol)
- sync-policies authoring (`create`/`update`/`delete`/`evaluate`/`preview`)

No matrix edits (orchestrator owns the matrix).

Part of #40
Closes #77

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full suite run three times in parallel (CI-style) after rebasing onto latest main: 493 tests in 61 suites, all passing, no flake.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements
- [ ] N/A - no UI changes