### PR TITLE
feat(ios): format handlers list, detail, and enable/disable

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -8,8 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		0050E6CD740666B06CF4F1F6 /* DependencyTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */; };
+		026B8D82FD64E6F931CEBD27 /* FormatHandlerMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B9B36914B6DA1509EE21944 /* FormatHandlerMapping.swift */; };
 		03D59745AFA47FE8D1811B9A /* SecurityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7351368D8EDB157E264ECBBC /* SecurityView.swift */; };
 		045038A865E03603D632D162 /* ArtifactDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE37B413A2C453F93480A64 /* ArtifactDetailViewModel.swift */; };
+		04748111E3FAABFEADE548AB /* FormatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C058A6752E70917E07BE17F /* FormatsView.swift */; };
 		04B038DD0B0B8611B2FB91F2 /* ArtifactDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE2C5256F844F6279846227 /* ArtifactDetail.swift */; };
 		04D04D992D40CBE4A2A9A8D5 /* MonitoringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F6787AE2A18008C8EA282F /* MonitoringView.swift */; };
 		04E9EC2157EA947C8B9FE159 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C4236474392052DD29004F /* DashboardView.swift */; };
@@ -37,6 +39,7 @@
 		1AB249F434755BECF4124CA8 /* SetupInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113DC09E3B0845FAD9BDA8F6 /* SetupInstructionsView.swift */; };
 		1CC2147E6995CB8C42B11A2A /* ScanConfigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */; };
 		1EB081D63A5092425E75A0B0 /* RepositoryDetailTabbedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FEF3A0FA55ECC63DDC8899F /* RepositoryDetailTabbedView.swift */; };
+		1FC9B86A1DA9C002D72C941A /* FormatHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2E4034C9725D438C6A6A1C /* FormatHandler.swift */; };
 		2052B7B0961EC927404CD8F1 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8267620B852D7914EAD83DAE /* SettingsView.swift */; };
 		21792E2823728B81B6E3E621 /* RepositoryTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517D78FD253D2202880EF013 /* RepositoryTreeView.swift */; };
 		22DD061A91C6E4E41682EC60 /* SetupInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113DC09E3B0845FAD9BDA8F6 /* SetupInstructionsView.swift */; };
@@ -56,6 +59,7 @@
 		32C0A53DAE5CEA63670B57F2 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 36656CBAF76FAB0F5ECC7855 /* Alamofire */; };
 		32DCAA417773BE4B603C28D9 /* InstallPluginFromGitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DD24CE59A14232D46D4665 /* InstallPluginFromGitView.swift */; };
 		3366AEE087831CF15004691F /* DashboardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */; };
+		346F09AA53B575008E00A611 /* FormatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C058A6752E70917E07BE17F /* FormatsView.swift */; };
 		363B3E9588A4895C999757BC /* PackagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C67E4A61ED479E094891F7 /* PackagesView.swift */; };
 		389A90FAD7E4FDA7B8464B92 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73AE1952EFB3C338C7D0771 /* LoginView.swift */; };
 		38E52404189326A2143B485E /* ArtifactsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E44194ACD18BA49B67189B /* ArtifactsSectionView.swift */; };
@@ -89,6 +93,7 @@
 		5C6497F001D512DDC978EA47 /* UsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8761FACD0287EF99C0A1E50 /* UsersView.swift */; };
 		5DC6ADC742245FD8E111A33E /* ArtifactSecurityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F832901A43DC98CC288AA4 /* ArtifactSecurityView.swift */; };
 		5E0D22452C4DCD3E0ECCEED2 /* Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA65CF7CCFDB01286A0C408 /* Integration.swift */; };
+		5E40B65D0289E04671BA7013 /* FormatHandlerDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24AFA26AFBFA0C92090DC99 /* FormatHandlerDispatchTests.swift */; };
 		5E51BAB787218813CAC5477D /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9415E01C2D644848CDBB4D0 /* Theme.swift */; };
 		5EF2BD42EC4E974AAA06824C /* StagingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F60553EA149CE733245164B /* StagingDetailView.swift */; };
 		5F2BF946886E0871236036AC /* ArtifactKeeperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D217BC8D6B2994A881C4E04E /* ArtifactKeeperApp.swift */; };
@@ -139,6 +144,7 @@
 		94F8DAE6FEDABE840D272740 /* AccountToolbarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A527DEEF9DECA3F2E8EC26 /* AccountToolbarModifier.swift */; };
 		94FC8121D7F395B27138FF6C /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 3706EE4D071525F8E60A5A3B /* Kingfisher */; };
 		95AFE5BD66F78CB88FB2ABA1 /* PeersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F130C4E4EC403EC23594AE44 /* PeersView.swift */; };
+		95B32C90B06041B7F45466B8 /* FormatHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2E4034C9725D438C6A6A1C /* FormatHandler.swift */; };
 		9770642EBFBB24D77727C5B5 /* TOTPVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB4EEF15843269173A9B772 /* TOTPVerificationView.swift */; };
 		983F1AE2C41B80CC7F6F9577 /* OperationsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6A94422BAD7B966077C0D9 /* OperationsSectionView.swift */; };
 		99C3358F603E8600CA038F75 /* DashboardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */; };
@@ -171,6 +177,7 @@
 		B7F76BE14A732DCCD7EDF405 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81FFEFE5A4DE0397D840007 /* KeychainManager.swift */; };
 		B85DD5AD52ECDF8AF03AD72F /* SbomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACFAEE53DF20945E710A82E /* SbomView.swift */; };
 		B88EC39592199C1C4E1FB621 /* PackagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C67E4A61ED479E094891F7 /* PackagesView.swift */; };
+		BB0355D62EC2DFC1AF0ADCA9 /* FormatHandlerMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7066EA876C79A44B886A81F7 /* FormatHandlerMappingTests.swift */; };
 		BCD82AAFB0CAB353C5CABAD2 /* RepositoryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862E1C3205340290276A9B75 /* RepositoryTree.swift */; };
 		BF54F129B023787CC9A44249 /* SecurityMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF4590E6775407858BBAC86 /* SecurityMappingTests.swift */; };
 		C003F153FD58DC40599D6AA3 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9050B925E8CDAB492ED01C01 /* AnalyticsView.swift */; };
@@ -188,6 +195,7 @@
 		CE29910E19439190B021FD6B /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F86EB93D00E4631A8F8F9C /* Artifact.swift */; };
 		D0480DCE5F0F50B390F15993 /* ArtifactDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE37B413A2C453F93480A64 /* ArtifactDetailViewModel.swift */; };
 		D11B924C3B8CFCE3F0E46905 /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */; };
+		D2927E3F310D52B6E0524FC8 /* FormatHandlerDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24AFA26AFBFA0C92090DC99 /* FormatHandlerDispatchTests.swift */; };
 		D3653822D6C8332BC92D8642 /* SSOView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C66794630C443427F1527 /* SSOView.swift */; };
 		D36FF1BE98A8940CC8E38C27 /* DependencyTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */; };
 		D40943078196189E5E593C67 /* SDKClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */; };
@@ -202,12 +210,14 @@
 		DD9C336F7D973FA27ACD095E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155377690C14964BAFBAF481 /* ProfileView.swift */; };
 		DF321600060A4DA7993785FF /* Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBE59905B179E64919791A7 /* Admin.swift */; };
 		DF3A3118CF4C5C19CDC19B56 /* VirtualMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F508C0FBF498EB51BC64EE /* VirtualMember.swift */; };
+		E0CD29A224134EB32F9D827D /* FormatHandlerMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B9B36914B6DA1509EE21944 /* FormatHandlerMapping.swift */; };
 		E15A1D5EA6FDA4D8DAF42CF7 /* QualityMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8211F9D04C3BF74AB42324D9 /* QualityMappingTests.swift */; };
 		E18E74AC77451E6C0022B276 /* Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBE59905B179E64919791A7 /* Admin.swift */; };
 		E2678146D7F808D22B485573 /* SecurityDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */; };
 		E4618623F8473A8661B7CC6F /* ChangePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7812397531D2CD01F4488BC6 /* ChangePasswordView.swift */; };
 		E57D1E3FC479A28A54467A5B /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DDB4F8B15C1FB99A2843 /* Package.swift */; };
 		E95246F33B27251305C22435 /* PluginsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F05BA048E8B88FD14314F17 /* PluginsView.swift */; };
+		E9C8B68366AA51473653BCE4 /* FormatHandlerMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7066EA876C79A44B886A81F7 /* FormatHandlerMappingTests.swift */; };
 		EA935E6E499F8A518FCBA8C3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3E2D65A21BA60C8957EE36 /* ContentView.swift */; };
 		EAC22A0EE22A2528BABD2C6B /* Build.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90190CE35DA804C357A5FFDB /* Build.swift */; };
 		EBBA4D16B78FD192D954563C /* BuildsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E5BB60BE578603D5B6925 /* BuildsView.swift */; };
@@ -254,6 +264,7 @@
 		1464BFA481535D3C3B4F4CC5 /* GroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupsView.swift; sourceTree = "<group>"; };
 		155377690C14964BAFBAF481 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		1901D688CCAD3DE71AA681AC /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
+		1B9B36914B6DA1509EE21944 /* FormatHandlerMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatHandlerMapping.swift; sourceTree = "<group>"; };
 		1C63C47E06CD6C0372C017A2 /* CveLicensePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CveLicensePathTests.swift; sourceTree = "<group>"; };
 		1DB4EEF15843269173A9B772 /* TOTPVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPVerificationView.swift; sourceTree = "<group>"; };
 		26DD24CE59A14232D46D4665 /* InstallPluginFromGitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallPluginFromGitView.swift; sourceTree = "<group>"; };
@@ -279,11 +290,13 @@
 		59F86EB93D00E4631A8F8F9C /* Artifact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artifact.swift; sourceTree = "<group>"; };
 		5B3E2D65A21BA60C8957EE36 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		5B6A94422BAD7B966077C0D9 /* OperationsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationsSectionView.swift; sourceTree = "<group>"; };
+		5C058A6752E70917E07BE17F /* FormatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatsView.swift; sourceTree = "<group>"; };
 		5DAF919B4CECF39C3787DD94 /* LicensePoliciesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensePoliciesView.swift; sourceTree = "<group>"; };
 		65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerManagerTests.swift; sourceTree = "<group>"; };
 		6A41A1778E2034F039852708 /* ArtifactDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailTests.swift; sourceTree = "<group>"; };
 		6FE2C5256F844F6279846227 /* ArtifactDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetail.swift; sourceTree = "<group>"; };
 		6FE37B413A2C453F93480A64 /* ArtifactDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDetailViewModel.swift; sourceTree = "<group>"; };
+		7066EA876C79A44B886A81F7 /* FormatHandlerMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatHandlerMappingTests.swift; sourceTree = "<group>"; };
 		71D58BAA440C3500A2CBD775 /* APIClientExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientExtendedTests.swift; sourceTree = "<group>"; };
 		72273F4294E6BC2DA2D09609 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		7351368D8EDB157E264ECBBC /* SecurityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityView.swift; sourceTree = "<group>"; };
@@ -294,6 +307,7 @@
 		783C66794630C443427F1527 /* SSOView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSOView.swift; sourceTree = "<group>"; };
 		785B2E0E832C8B70BD268404 /* APIClientNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientNetworkTests.swift; sourceTree = "<group>"; };
 		79512BEEB0DBDA10DFDCFAAC /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		7B2E4034C9725D438C6A6A1C /* FormatHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatHandler.swift; sourceTree = "<group>"; };
 		7FEF3A0FA55ECC63DDC8899F /* RepositoryDetailTabbedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailTabbedView.swift; sourceTree = "<group>"; };
 		8063DEF3B0228C26496797B7 /* WebhooksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhooksView.swift; sourceTree = "<group>"; };
 		8067728F7917AD61F0DB4037 /* ReplicationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplicationView.swift; sourceTree = "<group>"; };
@@ -322,6 +336,7 @@
 		ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSecurityConfig.swift; sourceTree = "<group>"; };
 		AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanConfigsView.swift; sourceTree = "<group>"; };
 		B1164C99171DC47A99F71C0D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B24AFA26AFBFA0C92090DC99 /* FormatHandlerDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatHandlerDispatchTests.swift; sourceTree = "<group>"; };
 		B6F9DDB4F8B15C1FB99A2843 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		BD2E5BB60BE578603D5B6925 /* BuildsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildsView.swift; sourceTree = "<group>"; };
 		C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyTrack.swift; sourceTree = "<group>"; };
@@ -430,6 +445,8 @@
 				F84212AD84A94810D2C23339 /* AuthManagerTests.swift */,
 				1C63C47E06CD6C0372C017A2 /* CveLicensePathTests.swift */,
 				888D1A2EB554E8903CED4CF3 /* DashboardViewTests.swift */,
+				B24AFA26AFBFA0C92090DC99 /* FormatHandlerDispatchTests.swift */,
+				7066EA876C79A44B886A81F7 /* FormatHandlerMappingTests.swift */,
 				AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */,
 				942CFADFFB28FA592F32CAB1 /* ModelTests.swift */,
 				4147C420ECCBB9137917722C /* PluginPathTests.swift */,
@@ -495,6 +512,7 @@
 				E59705D3B5F2000ACABB8A48 /* Auth.swift */,
 				90190CE35DA804C357A5FFDB /* Build.swift */,
 				C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */,
+				7B2E4034C9725D438C6A6A1C /* FormatHandler.swift */,
 				FCA65CF7CCFDB01286A0C408 /* Integration.swift */,
 				C5CFB90021A1428D8962F1BF /* Operations.swift */,
 				B6F9DDB4F8B15C1FB99A2843 /* Package.swift */,
@@ -630,6 +648,7 @@
 			isa = PBXGroup;
 			children = (
 				3412EF9765589F0F5C9613ED /* APIClient.swift */,
+				1B9B36914B6DA1509EE21944 /* FormatHandlerMapping.swift */,
 				CF539B04F8B6390EDFE0643B /* QualityMapping.swift */,
 				974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */,
 				AC7BD8467BED7C0A6ECE6DBE /* SecurityMapping.swift */,
@@ -702,6 +721,7 @@
 		F17866B4DADD535323D2A2E4 /* Integration */ = {
 			isa = PBXGroup;
 			children = (
+				5C058A6752E70917E07BE17F /* FormatsView.swift */,
 				26DD24CE59A14232D46D4665 /* InstallPluginFromGitView.swift */,
 				F130C4E4EC403EC23594AE44 /* PeersView.swift */,
 				8F05BA048E8B88FD14314F17 /* PluginsView.swift */,
@@ -875,6 +895,8 @@
 				43CD93CC42B93AE1999FA8B9 /* AuthManagerTests.swift in Sources */,
 				062126612F89F0FAE35077F2 /* CveLicensePathTests.swift in Sources */,
 				99C3358F603E8600CA038F75 /* DashboardViewTests.swift in Sources */,
+				5E40B65D0289E04671BA7013 /* FormatHandlerDispatchTests.swift in Sources */,
+				E9C8B68366AA51473653BCE4 /* FormatHandlerMappingTests.swift in Sources */,
 				ECE469E91BEE0E35EB258F98 /* KeychainManagerTests.swift in Sources */,
 				FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */,
 				293314A1B0346F707F5B3CE4 /* PluginPathTests.swift in Sources */,
@@ -917,6 +939,9 @@
 				083E2EBD72FFCF6E3EDEA31B /* DtDashboardView.swift in Sources */,
 				B42C3893B88FDD3E8D354DB5 /* DtProjectsView.swift in Sources */,
 				87DFC05DFE36A27A9C5769A6 /* EditRepositorySheet.swift in Sources */,
+				1FC9B86A1DA9C002D72C941A /* FormatHandler.swift in Sources */,
+				E0CD29A224134EB32F9D827D /* FormatHandlerMapping.swift in Sources */,
+				346F09AA53B575008E00A611 /* FormatsView.swift in Sources */,
 				B711A4EF6DF167F16406CBD3 /* GroupsView.swift in Sources */,
 				6D02C2A0C45C6E1D0AA70FE2 /* HealthDashboardView.swift in Sources */,
 				0A3760D03332F2FC23F5BCC3 /* InstallPluginFromGitView.swift in Sources */,
@@ -992,6 +1017,8 @@
 				653D84744E6345714FCE559A /* AuthManagerTests.swift in Sources */,
 				7D990B45FF3ECE2858347141 /* CveLicensePathTests.swift in Sources */,
 				3366AEE087831CF15004691F /* DashboardViewTests.swift in Sources */,
+				D2927E3F310D52B6E0524FC8 /* FormatHandlerDispatchTests.swift in Sources */,
+				BB0355D62EC2DFC1AF0ADCA9 /* FormatHandlerMappingTests.swift in Sources */,
 				6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */,
 				83D01D48B7B7C3739E1344B3 /* ModelTests.swift in Sources */,
 				B18AAE17086834FBB57455D9 /* PluginPathTests.swift in Sources */,
@@ -1034,6 +1061,9 @@
 				AF076028A446FB1E28446D96 /* DtDashboardView.swift in Sources */,
 				B21993AEB170DF2F11F595FC /* DtProjectsView.swift in Sources */,
 				638F88CF707835320776D7D7 /* EditRepositorySheet.swift in Sources */,
+				95B32C90B06041B7F45466B8 /* FormatHandler.swift in Sources */,
+				026B8D82FD64E6F931CEBD27 /* FormatHandlerMapping.swift in Sources */,
+				04748111E3FAABFEADE548AB /* FormatsView.swift in Sources */,
 				0D2124206E78085A90971F0A /* GroupsView.swift in Sources */,
 				7C9F12D37482E704E49A3814 /* HealthDashboardView.swift in Sources */,
 				32DCAA417773BE4B603C28D9 /* InstallPluginFromGitView.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -541,6 +541,40 @@ actor APIClient {
         try await requestVoid("/api/v1/plugins/\(id)", method: "DELETE")
     }
 
+    // MARK: Format Handlers (Integration, SDK-backed)
+
+    /// List all registered format handlers (GET /api/v1/formats).
+    func listFormatHandlers() async throws -> [FormatHandler] {
+        let client = await sdkClientInstance()
+        let response = try await client.list_format_handlers()
+        let data = try response.ok.body.json
+        return data.map { FormatHandler(from: $0) }
+    }
+
+    /// Fetch a single format handler by key (GET /api/v1/formats/{format_key}).
+    func getFormatHandler(formatKey: String) async throws -> FormatHandler {
+        let client = await sdkClientInstance()
+        let response = try await client.get_format_handler(path: .init(format_key: formatKey))
+        let data = try response.ok.body.json
+        return FormatHandler(from: data)
+    }
+
+    /// Enable a format handler (POST /api/v1/formats/{format_key}/enable).
+    func enableFormatHandler(formatKey: String) async throws -> FormatHandler {
+        let client = await sdkClientInstance()
+        let response = try await client.enable_format_handler(path: .init(format_key: formatKey))
+        let data = try response.ok.body.json
+        return FormatHandler(from: data)
+    }
+
+    /// Disable a format handler (POST /api/v1/formats/{format_key}/disable).
+    func disableFormatHandler(formatKey: String) async throws -> FormatHandler {
+        let client = await sdkClientInstance()
+        let response = try await client.disable_format_handler(path: .init(format_key: formatKey))
+        let data = try response.ok.body.json
+        return FormatHandler(from: data)
+    }
+
     // MARK: Repository Tree Browse (1.2.1: GET /api/v1/tree)
 
     /// Fetch the repository tree at a given path. Pass an empty path for the root.

--- a/ArtifactKeeper/Sources/Core/API/FormatHandlerMapping.swift
+++ b/ArtifactKeeper/Sources/Core/API/FormatHandlerMapping.swift
@@ -1,0 +1,27 @@
+import Foundation
+import ArtifactKeeperClient
+
+// MARK: - SDK -> App Model Mapping (Format Handlers)
+//
+// Mirrors the other mapping files: the generated client returns snake_case
+// fields, Int32 counts and Foundation.Date timestamps; the view layer uses the
+// camelCase FormatHandler model with Int and ISO8601 date strings.
+
+extension FormatHandler {
+    init(from sdk: Components.Schemas.FormatHandlerResponse) {
+        self.init(
+            id: sdk.id,
+            formatKey: sdk.format_key,
+            handlerType: sdk.handler_type.rawValue,
+            displayName: sdk.display_name,
+            description: sdk.description,
+            extensions: sdk.extensions,
+            isEnabled: sdk.is_enabled,
+            priority: Int(sdk.priority),
+            pluginId: sdk.plugin_id,
+            repositoryCount: sdk.repository_count.map(Int.init),
+            createdAt: SecurityMapping.isoString(sdk.created_at),
+            updatedAt: SecurityMapping.isoString(sdk.updated_at)
+        )
+    }
+}

--- a/ArtifactKeeper/Sources/Core/Models/FormatHandler.swift
+++ b/ArtifactKeeper/Sources/Core/Models/FormatHandler.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// MARK: - Format Handlers (1.2.1 /api/v1/formats/*)
+
+/// A registered format handler (GET /api/v1/formats, GET /api/v1/formats/{format_key}).
+/// Handlers are either compiled-in (Core) or loaded from a WASM plugin (Wasm).
+struct FormatHandler: Codable, Identifiable, Sendable, Equatable {
+    let id: String
+    let formatKey: String
+    let handlerType: String
+    let displayName: String
+    let description: String?
+    let extensions: [String]
+    let isEnabled: Bool
+    let priority: Int
+    let pluginId: String?
+    let repositoryCount: Int?
+    let createdAt: String
+    let updatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, description, extensions, priority
+        case formatKey = "format_key"
+        case handlerType = "handler_type"
+        case displayName = "display_name"
+        case isEnabled = "is_enabled"
+        case pluginId = "plugin_id"
+        case repositoryCount = "repository_count"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Integration/FormatsView.swift
+++ b/ArtifactKeeper/Sources/Features/Integration/FormatsView.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+
+/// Lists the registered format handlers (GET /api/v1/formats) and lets an
+/// operator inspect one (GET /api/v1/formats/{format_key}) and enable or disable
+/// it (POST .../enable | .../disable).
+struct FormatsView: View {
+    @State private var handlers: [FormatHandler] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var mutatingKey: String?
+    @State private var actionMessage: (success: Bool, text: String)?
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading format handlers\u{2026}")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = errorMessage {
+                ContentUnavailableView {
+                    Label("Formats Unavailable", systemImage: "shippingbox")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Retry") { Task { await load() } }
+                        .buttonStyle(.borderedProminent)
+                }
+            } else if handlers.isEmpty {
+                ContentUnavailableView(
+                    "No Format Handlers",
+                    systemImage: "shippingbox",
+                    description: Text("No format handlers are registered.")
+                )
+            } else {
+                List {
+                    if let actionMessage {
+                        Section {
+                            HStack(spacing: 8) {
+                                Image(systemName: actionMessage.success ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    .foregroundStyle(actionMessage.success ? .green : .red)
+                                Text(actionMessage.text)
+                                    .font(.caption)
+                                    .foregroundStyle(actionMessage.success ? .green : .red)
+                            }
+                        }
+                    }
+                    ForEach(handlers) { handler in
+                        NavigationLink {
+                            FormatHandlerDetailView(
+                                listHandler: handler,
+                                isMutating: mutatingKey == handler.formatKey,
+                                onToggle: { await toggle(handler) }
+                            )
+                        } label: {
+                            FormatHandlerRow(handler: handler)
+                        }
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .refreshable { await load() }
+        .task { await load() }
+    }
+
+    private func load() async {
+        isLoading = handlers.isEmpty
+        do {
+            handlers = try await apiClient.listFormatHandlers()
+                .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+            errorMessage = nil
+        } catch {
+            if handlers.isEmpty {
+                errorMessage = "Could not load format handlers. This feature may not be available on your server."
+            }
+        }
+        isLoading = false
+    }
+
+    private func toggle(_ handler: FormatHandler) async {
+        mutatingKey = handler.formatKey
+        defer { mutatingKey = nil }
+        do {
+            if handler.isEnabled {
+                _ = try await apiClient.disableFormatHandler(formatKey: handler.formatKey)
+                actionMessage = (true, "\(handler.displayName) disabled.")
+            } else {
+                _ = try await apiClient.enableFormatHandler(formatKey: handler.formatKey)
+                actionMessage = (true, "\(handler.displayName) enabled.")
+            }
+            await load()
+        } catch {
+            actionMessage = (false, "Failed to update \(handler.displayName): \(error.localizedDescription)")
+        }
+    }
+}
+
+private struct FormatHandlerRow: View {
+    let handler: FormatHandler
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: handler.isEnabled ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(handler.isEnabled ? Color.green : Color.secondary)
+                Text(handler.displayName)
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+                Text(handler.handlerType)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(handler.handlerType == "Wasm" ? Color.purple.opacity(0.15) : Color.blue.opacity(0.15), in: Capsule())
+                    .foregroundStyle(handler.handlerType == "Wasm" ? .purple : .blue)
+            }
+            HStack(spacing: 8) {
+                Text(handler.formatKey)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let count = handler.repositoryCount {
+                    Text("\u{00B7} \(count) repo\(count == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Detail for one format handler. Re-fetches by key on appear so a stale list
+/// value is refreshed, and offers an enable/disable toggle.
+struct FormatHandlerDetailView: View {
+    let listHandler: FormatHandler
+    let isMutating: Bool
+    let onToggle: () async -> Void
+
+    @State private var fetched: FormatHandler?
+    @State private var loadError: String?
+
+    private let apiClient = APIClient.shared
+
+    private var handler: FormatHandler { fetched ?? listHandler }
+
+    var body: some View {
+        List {
+            if let loadError {
+                Section {
+                    Label(loadError, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Handler") {
+                detailRow("Name", handler.displayName)
+                detailRow("Format", handler.formatKey)
+                detailRow("Type", handler.handlerType)
+                detailRow("Status", handler.isEnabled ? "Enabled" : "Disabled")
+                detailRow("Priority", "\(handler.priority)")
+                if let count = handler.repositoryCount {
+                    detailRow("Repositories", "\(count)")
+                }
+            }
+
+            if let description = handler.description, !description.isEmpty {
+                Section("Description") {
+                    Text(description).font(.subheadline)
+                }
+            }
+
+            if !handler.extensions.isEmpty {
+                Section("Extensions") {
+                    Text(handler.extensions.joined(separator: ", "))
+                        .font(.subheadline)
+                }
+            }
+
+            Section {
+                Button {
+                    Task { await onToggle() }
+                } label: {
+                    Label(handler.isEnabled ? "Disable" : "Enable",
+                          systemImage: handler.isEnabled ? "pause.circle" : "play.circle")
+                }
+                .disabled(isMutating)
+            }
+        }
+        .navigationTitle(handler.displayName)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { await loadDetail() }
+        .refreshable { await loadDetail() }
+    }
+
+    private func loadDetail() async {
+        do {
+            fetched = try await apiClient.getFormatHandler(formatKey: listHandler.formatKey)
+            loadError = nil
+        } catch {
+            loadError = "Showing cached details; could not refresh: \(error.localizedDescription)"
+        }
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).multilineTextAlignment(.trailing)
+        }
+        .font(.subheadline)
+    }
+}

--- a/ArtifactKeeper/Sources/Sections/IntegrationSectionView.swift
+++ b/ArtifactKeeper/Sources/Sections/IntegrationSectionView.swift
@@ -11,6 +11,7 @@ struct IntegrationSectionView: View {
                     Text("Replication").tag("replication")
                     Text("Webhooks").tag("webhooks")
                     Text("Plugins").tag("plugins")
+                    Text("Formats").tag("formats")
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
@@ -28,6 +29,8 @@ struct IntegrationSectionView: View {
                         WebhooksView()
                     case "plugins":
                         PluginsView()
+                    case "formats":
+                        FormatsView()
                     default:
                         EmptyView()
                     }

--- a/ArtifactKeeper/Tests/FormatHandlerDispatchTests.swift
+++ b/ArtifactKeeper/Tests/FormatHandlerDispatchTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import Foundation
+import ArtifactKeeperClient
+@testable import ArtifactKeeper
+
+// Path-pinning tests for the SDK-backed format handler methods on APIClient.
+// Each test drives the real production method through a RecordingTransport
+// (defined in SecurityDispatchTests.swift, same target) with a runtime format
+// key and asserts the request path, method, and operation id. A canned body lets
+// the array case decode; single-object cases use `try?` since the empty object
+// is recorded before it fails to decode.
+
+@Suite("Format Handler SDK Dispatch Tests")
+struct FormatHandlerDispatchTests {
+
+    private func makeClient() async -> (APIClient, RecordingTransport) {
+        let transport = RecordingTransport()
+        let sdk = Client(
+            serverURL: URL(string: "https://example.test")!,
+            transport: transport
+        )
+        let api = APIClient(baseURL: "https://example.test", session: .shared)
+        await api.setSDKClientForTesting(sdk)
+        return (api, transport)
+    }
+
+    private func path(_ p: String?) -> String {
+        guard let p else { return "" }
+        return String(p.split(separator: "?", maxSplits: 1)[0])
+    }
+
+    @Test func listFormatHandlersHitsFormatsPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try await api.listFormatHandlers()
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(path(rec?.path) == "/api/v1/formats")
+        #expect(rec?.operationID == "list_format_handlers")
+    }
+
+    @Test func getFormatHandlerHitsFormatByKeyPath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.getFormatHandler(formatKey: "maven")
+
+        let rec = transport.last
+        #expect(rec?.method == "GET")
+        #expect(path(rec?.path) == "/api/v1/formats/maven")
+        #expect(rec?.operationID == "get_format_handler")
+    }
+
+    @Test func enableFormatHandlerHitsEnablePath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.enableFormatHandler(formatKey: "npm")
+
+        let rec = transport.last
+        #expect(rec?.method == "POST")
+        #expect(path(rec?.path) == "/api/v1/formats/npm/enable")
+        #expect(rec?.operationID == "enable_format_handler")
+    }
+
+    @Test func disableFormatHandlerHitsDisablePath() async throws {
+        let (api, transport) = await makeClient()
+
+        _ = try? await api.disableFormatHandler(formatKey: "npm")
+
+        let rec = transport.last
+        #expect(rec?.method == "POST")
+        #expect(path(rec?.path) == "/api/v1/formats/npm/disable")
+        #expect(rec?.operationID == "disable_format_handler")
+    }
+}

--- a/ArtifactKeeper/Tests/FormatHandlerMappingTests.swift
+++ b/ArtifactKeeper/Tests/FormatHandlerMappingTests.swift
@@ -1,0 +1,69 @@
+import Testing
+import Foundation
+import ArtifactKeeperClient
+@testable import ArtifactKeeper
+
+@Suite("Format Handler SDK Mapping Tests")
+struct FormatHandlerMappingTests {
+
+    private static let created = Date(timeIntervalSince1970: 1_700_000_000)
+    private static let updated = Date(timeIntervalSince1970: 1_700_086_400)
+
+    @Test func formatHandlerMapsAllFields() {
+        let sdk = Components.Schemas.FormatHandlerResponse(
+            capabilities: nil,
+            created_at: Self.created,
+            description: "Maven repository format",
+            display_name: "Maven",
+            extensions: ["jar", "pom"],
+            format_key: "maven",
+            handler_type: .Core,
+            id: "fmt-1",
+            is_enabled: true,
+            plugin_id: nil,
+            priority: 10,
+            repository_count: 4,
+            updated_at: Self.updated
+        )
+
+        let model = FormatHandler(from: sdk)
+
+        #expect(model.id == "fmt-1")
+        #expect(model.formatKey == "maven")
+        #expect(model.handlerType == "Core")
+        #expect(model.displayName == "Maven")
+        #expect(model.description == "Maven repository format")
+        #expect(model.extensions == ["jar", "pom"])
+        #expect(model.isEnabled)
+        #expect(model.priority == 10)
+        #expect(model.pluginId == nil)
+        #expect(model.repositoryCount == 4)
+        #expect(model.createdAt == SecurityMapping.isoString(Self.created))
+        #expect(model.updatedAt == SecurityMapping.isoString(Self.updated))
+    }
+
+    @Test func wasmHandlerTypeMaps() {
+        let sdk = Components.Schemas.FormatHandlerResponse(
+            capabilities: nil,
+            created_at: Self.created,
+            description: nil,
+            display_name: "Unity",
+            extensions: ["unitypackage"],
+            format_key: "unity",
+            handler_type: .Wasm,
+            id: "fmt-2",
+            is_enabled: false,
+            plugin_id: "plg-9",
+            priority: 5,
+            repository_count: nil,
+            updated_at: Self.updated
+        )
+
+        let model = FormatHandler(from: sdk)
+
+        #expect(model.handlerType == "Wasm")
+        #expect(!model.isEnabled)
+        #expect(model.pluginId == "plg-9")
+        #expect(model.repositoryCount == nil)
+    }
+}

--- a/ArtifactKeeper/Tests/SecurityDispatchTests.swift
+++ b/ArtifactKeeper/Tests/SecurityDispatchTests.swift
@@ -49,7 +49,8 @@ final class RecordingTransport: ClientTransport, @unchecked Sendable {
         switch operationID {
         case "list_artifact_scans", "list_findings", "list_repo_scans":
             return #"{"items":[],"total":0}"#
-        case "get_sbom_components", "get_all_scores", "list_scan_configs", "list_gates":
+        case "get_sbom_components", "get_all_scores", "list_scan_configs", "list_gates",
+             "list_format_handlers":
             return "[]"
         default:
             return "{}"


### PR DESCRIPTION
## Summary
Adds a **Formats** tab to the Integration section covering the format handler family.

Lists all registered format handlers (`GET /api/v1/formats`) with their type (Core / Wasm), format key, and repository count. Tapping a handler opens a detail that re-fetches by key on `.task` (`GET /api/v1/formats/{format_key}`) and shows extensions, priority, and description, with an enable/disable toggle (`POST .../enable` | `.../disable`).

Implementation follows the existing SDK-backed style:
- `FormatHandler` model + `FormatHandlerMapping` conversion from the generated `FormatHandlerResponse`
- `APIClient` methods: `listFormatHandlers`, `getFormatHandler`, `enableFormatHandler`, `disableFormatHandler`
- Views with loading / error-with-retry / empty states, refreshable, Dynamic Type, dark mode, accessibility-combined rows
- Detail re-fetches by key (does not reuse the list value)

### Resolved ops
- `list_format_handlers` (GET /api/v1/formats)
- `get_format_handler` (GET /api/v1/formats/{format_key})
- `enable_format_handler` (POST /api/v1/formats/{format_key}/enable)
- `disable_format_handler` (POST /api/v1/formats/{format_key}/disable)

### Deferred
- `test_format_handler` (POST /api/v1/formats/{format_key}/test) -- requires base64 content authoring, an upload-style flow better suited to the web UI

Closes #79
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Path-pinning dispatch tests drive the real methods through `RecordingTransport` with runtime format keys and assert each hits the correct path/operation (`listFormatHandlersHitsFormatsPath`, `getFormatHandlerHitsFormatByKeyPath`, `enableFormatHandlerHitsEnablePath`, `disableFormatHandlerHitsDisablePath`). Mapping tests cover Core and Wasm handlers. Full suite green: 498 tests.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements