### PR TITLE
feat(ios): CVE history detail with status change (get_cve_history UI + update_cve_status)

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		435F616F353CDF139BE4859E /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F289613B7B5E1B85C3F9E832 /* ArtifactDetailView.swift */; };
 		43CD93CC42B93AE1999FA8B9 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84212AD84A94810D2C23339 /* AuthManagerTests.swift */; };
 		45EF793A77005F62C4263D1E /* WebhookPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D532EA4136F5C5CF5548AE /* WebhookPathTests.swift */; };
+		463C7D9720887BA8C9449710 /* CveHistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B8C85944DE179E8F1750EF /* CveHistoryDetailView.swift */; };
 		475F7C0CA9365AB11D952814 /* ReplicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8067728F7917AD61F0DB4037 /* ReplicationView.swift */; };
 		47DFA7F8B01E5A21906642A2 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9DDB4F8B15C1FB99A2843 /* Package.swift */; };
 		4A9D08A77DCBD1954B4CB334 /* Quality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28281FCD705C9F9F4DF23AF7 /* Quality.swift */; };
@@ -112,6 +113,7 @@
 		78A16F7733A939DF72627EAA /* OperationsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6A94422BAD7B966077C0D9 /* OperationsSectionView.swift */; };
 		7926AACBA3FC6E057D5340FE /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C4236474392052DD29004F /* DashboardView.swift */; };
 		797AE3D1C3726C2AAA195E4D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3E2D65A21BA60C8957EE36 /* ContentView.swift */; };
+		7A98B50F5AFC9B536392E6AB /* CveHistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B8C85944DE179E8F1750EF /* CveHistoryDetailView.swift */; };
 		7B983BDEC8F0E8548B9E7E5E /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1901D688CCAD3DE71AA681AC /* APIClientTests.swift */; };
 		7C9F12D37482E704E49A3814 /* HealthDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AB45AA08A0DE4EA42BC041 /* HealthDashboardView.swift */; };
 		7D990B45FF3ECE2858347141 /* CveLicensePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63C47E06CD6C0372C017A2 /* CveLicensePathTests.swift */; };
@@ -353,6 +355,7 @@
 		F8761FACD0287EF99C0A1E50 /* UsersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersView.swift; sourceTree = "<group>"; };
 		F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityDispatchTests.swift; sourceTree = "<group>"; };
 		F9415E01C2D644848CDBB4D0 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		F9B8C85944DE179E8F1750EF /* CveHistoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CveHistoryDetailView.swift; sourceTree = "<group>"; };
 		FCA65CF7CCFDB01286A0C408 /* Integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Integration.swift; sourceTree = "<group>"; };
 		FD29BEA4F2708262CE34F2E3 /* SecuritySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuritySectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -461,6 +464,7 @@
 			isa = PBXGroup;
 			children = (
 				26F832901A43DC98CC288AA4 /* ArtifactSecurityView.swift */,
+				F9B8C85944DE179E8F1750EF /* CveHistoryDetailView.swift */,
 				50DB58698E8E2409CAFE93AA /* CveHistoryView.swift */,
 				59106973EB99FD9424D44224 /* DtDashboardView.swift */,
 				07736CEE9959BC4566162E12 /* DtProjectsView.swift */,
@@ -911,6 +915,7 @@
 				EBBA4D16B78FD192D954563C /* BuildsView.swift in Sources */,
 				E4618623F8473A8661B7CC6F /* ChangePasswordView.swift in Sources */,
 				797AE3D1C3726C2AAA195E4D /* ContentView.swift in Sources */,
+				7A98B50F5AFC9B536392E6AB /* CveHistoryDetailView.swift in Sources */,
 				941BDA39A576A8603BE0E7F7 /* CveHistoryView.swift in Sources */,
 				7926AACBA3FC6E057D5340FE /* DashboardView.swift in Sources */,
 				0050E6CD740666B06CF4F1F6 /* DependencyTrack.swift in Sources */,
@@ -1028,6 +1033,7 @@
 				0AB4F8101A72D6C81B34D496 /* BuildsView.swift in Sources */,
 				238DBF144A2302C11DE50388 /* ChangePasswordView.swift in Sources */,
 				EA935E6E499F8A518FCBA8C3 /* ContentView.swift in Sources */,
+				463C7D9720887BA8C9449710 /* CveHistoryDetailView.swift in Sources */,
 				19F5B56288A694863407E57B /* CveHistoryView.swift in Sources */,
 				04E9EC2157EA947C8B9FE159 /* DashboardView.swift in Sources */,
 				D36FF1BE98A8940CC8E38C27 /* DependencyTrack.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -892,6 +892,25 @@ actor APIClient {
         return try await request("/api/v1/sbom/cve/history/\(encoded)")
     }
 
+    /// Update the triage status of a CVE for a specific artifact
+    /// (POST /api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id}).
+    /// Returns the updated history record.
+    func updateCveStatusByArtifactCve(
+        artifactId: String,
+        cveId: String,
+        status: String,
+        reason: String? = nil
+    ) async throws -> CveHistoryEntry {
+        let encodedArtifact = artifactId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? artifactId
+        let encodedCve = cveId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? cveId
+        let body = UpdateCveStatusRequest(status: status, reason: reason)
+        return try await request(
+            "/api/v1/sbom/cve/status/by-artifact/\(encodedArtifact)/by-cve/\(encodedCve)",
+            method: "POST",
+            body: body
+        )
+    }
+
     /// Check a set of licenses against policy (POST /api/v1/sbom/check-compliance).
     func checkLicenseCompliance(licenses: [String], repositoryId: String? = nil) async throws -> LicenseCheckResult {
         let body = CheckLicenseComplianceRequest(licenses: licenses, repositoryId: repositoryId)

--- a/ArtifactKeeper/Sources/Core/Models/Sbom.swift
+++ b/ArtifactKeeper/Sources/Core/Models/Sbom.swift
@@ -32,11 +32,21 @@ enum PolicyAction: String, Codable, CaseIterable, Sendable {
     }
 }
 
-enum CveStatus: String, Codable, Sendable {
+enum CveStatus: String, Codable, Sendable, CaseIterable {
     case open
     case fixed
     case acknowledged
     case falsePositive = "false_positive"
+
+    /// Human-readable label for pickers and badges.
+    var label: String {
+        switch self {
+        case .open: return "Open"
+        case .fixed: return "Fixed"
+        case .acknowledged: return "Acknowledged"
+        case .falsePositive: return "False Positive"
+        }
+    }
 }
 
 // MARK: - SBOM Document
@@ -280,6 +290,12 @@ struct CheckLicenseComplianceRequest: Encodable {
         case licenses
         case repositoryId = "repository_id"
     }
+}
+
+/// Body for POST /api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id}.
+struct UpdateCveStatusRequest: Encodable {
+    let status: String
+    let reason: String?
 }
 
 // MARK: - AnyCodable helper for dynamic JSON

--- a/ArtifactKeeper/Sources/Features/Security/CveHistoryDetailView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/CveHistoryDetailView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+/// Single CVE history record detail. On appearance it re-fetches the record by id
+/// via APIClient.getCveHistory(id:) (GET /api/v1/sbom/cve/history/{id}) and renders
+/// the fetched value rather than reusing the list row. It also exposes a triage
+/// status change (open / acknowledged / false_positive / fixed + optional reason)
+/// via update_cve_status_by_artifact_cve, matching the Android operate action.
+struct CveHistoryDetailView: View {
+    /// The entry as known from the list, shown immediately while the by-id fetch
+    /// is in flight and used as the source of the runtime ids.
+    let listEntry: CveHistoryEntry
+
+    @State private var fetched: CveHistoryEntry?
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    @State private var selectedStatus: CveStatus = .open
+    @State private var reason = ""
+    @State private var isSaving = false
+    @State private var statusAlert: StatusAlert?
+
+    private let apiClient = APIClient.shared
+
+    /// The freshest record we have: the by-id fetch if it succeeded, else the list value.
+    private var entry: CveHistoryEntry { fetched ?? listEntry }
+
+    var body: some View {
+        Form {
+            if isLoading && fetched == nil {
+                Section {
+                    HStack {
+                        ProgressView().controlSize(.small)
+                        Text("Loading record\u{2026}").foregroundStyle(.secondary)
+                    }
+                }
+            } else if let loadError, fetched == nil {
+                Section {
+                    ContentUnavailableView {
+                        Label("Could Not Load", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(loadError)
+                    } actions: {
+                        Button("Retry") { Task { await load() } }
+                            .buttonStyle(.borderedProminent)
+                    }
+                }
+            } else {
+                detailSections
+            }
+        }
+        .navigationTitle(entry.cveId)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { await load() }
+        .refreshable { await load() }
+        .alert(item: $statusAlert) { alert in
+            Alert(title: Text(alert.title), message: Text(alert.message), dismissButton: .default(Text("OK")))
+        }
+    }
+
+    @ViewBuilder
+    private var detailSections: some View {
+        Section("Vulnerability") {
+            detailRow("CVE", entry.cveId)
+            if let severity = entry.severity {
+                detailRow("Severity", severity.capitalized)
+            }
+            if let score = entry.cvssScore {
+                detailRow("CVSS", String(format: "%.1f", score))
+            }
+            detailRow("Status", (CveStatus(rawValue: entry.status)?.label ?? entry.status.capitalized))
+            if let component = entry.affectedComponent {
+                detailRow("Component", "\(component)\(entry.affectedVersion.map { " @ \($0)" } ?? "")")
+            }
+            if let fixed = entry.fixedVersion, !fixed.isEmpty {
+                detailRow("Fixed In", fixed)
+            }
+        }
+
+        if let url = URL(string: "https://nvd.nist.gov/vuln/detail/\(entry.cveId)") {
+            Section {
+                Link(destination: url) {
+                    Label("View on NVD", systemImage: "arrow.up.right.square")
+                }
+            }
+        }
+
+        Section("Set Status") {
+            Picker("Status", selection: $selectedStatus) {
+                ForEach(CveStatus.allCases, id: \.self) { status in
+                    Text(status.label).tag(status)
+                }
+            }
+            TextField("Reason (optional)", text: $reason, axis: .vertical)
+                .lineLimit(1...3)
+            Button {
+                Task { await applyStatus() }
+            } label: {
+                if isSaving {
+                    HStack {
+                        ProgressView().controlSize(.small)
+                        Text("Saving\u{2026}")
+                    }
+                } else {
+                    Text("Update Status")
+                }
+            }
+            .disabled(isSaving || selectedStatus.rawValue == entry.status)
+        }
+    }
+
+    private func load() async {
+        isLoading = fetched == nil
+        do {
+            let record = try await apiClient.getCveHistory(id: listEntry.id)
+            fetched = record
+            selectedStatus = CveStatus(rawValue: record.status) ?? .open
+            loadError = nil
+        } catch {
+            if fetched == nil {
+                loadError = "Could not load this record: \(error.localizedDescription)"
+            }
+        }
+        isLoading = false
+    }
+
+    private func applyStatus() async {
+        isSaving = true
+        defer { isSaving = false }
+        let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            // Runtime ids come from the fetched record, not a hand-built path.
+            let updated = try await apiClient.updateCveStatusByArtifactCve(
+                artifactId: entry.artifactId,
+                cveId: entry.cveId,
+                status: selectedStatus.rawValue,
+                reason: trimmed.isEmpty ? nil : trimmed
+            )
+            fetched = updated
+            selectedStatus = CveStatus(rawValue: updated.status) ?? selectedStatus
+            reason = ""
+            statusAlert = StatusAlert(title: "Status Updated", message: "\(entry.cveId) is now \(selectedStatus.label).")
+        } catch {
+            statusAlert = StatusAlert(title: "Update Failed", message: error.localizedDescription)
+        }
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).multilineTextAlignment(.trailing)
+        }
+        .font(.subheadline)
+    }
+}
+
+private struct StatusAlert: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+}

--- a/ArtifactKeeper/Sources/Features/Security/CveHistoryView.swift
+++ b/ArtifactKeeper/Sources/Features/Security/CveHistoryView.swift
@@ -94,7 +94,11 @@ struct CveHistoryView: View {
         } else {
             List {
                 ForEach(entries) { entry in
-                    CveHistoryEntryRow(entry: entry)
+                    NavigationLink {
+                        CveHistoryDetailView(listEntry: entry)
+                    } label: {
+                        CveHistoryEntryRow(entry: entry)
+                    }
                 }
             }
             .listStyle(.plain)
@@ -128,7 +132,7 @@ private struct CveHistoryEntryRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
-                Link(entry.cveId, destination: URL(string: "https://nvd.nist.gov/vuln/detail/\(entry.cveId)")!)
+                Text(entry.cveId)
                     .font(.subheadline.weight(.semibold))
                 if let severity = entry.severity {
                     Text(severity.uppercased())

--- a/ArtifactKeeper/Tests/CveLicensePathTests.swift
+++ b/ArtifactKeeper/Tests/CveLicensePathTests.swift
@@ -87,6 +87,75 @@ struct CveLicensePathTests {
         #expect(methodBox.methods.contains("POST"))
         #expect(result.compliant)
     }
+
+    @Test func updateCveStatusTargetsByArtifactByCvePath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let recorder = PathRecorder()
+        let methodBox = MethodRecorder()
+        let bodyBox = BodyRecorder()
+        mock.handler = { request in
+            recorder.record(request.url!.path)
+            methodBox.record(request.httpMethod ?? "")
+            if let stream = request.httpBodyStream {
+                bodyBox.record(BodyRecorder.readStream(stream))
+            } else if let body = request.httpBody {
+                bodyBox.record(String(data: body, encoding: .utf8) ?? "")
+            }
+            return self.okResponse(request.url!, """
+            {
+              "id": "hist-3",
+              "artifact_id": "art-1",
+              "cve_id": "CVE-2024-9999",
+              "first_detected_at": "2024-01-01T00:00:00Z",
+              "last_detected_at": "2024-01-02T00:00:00Z",
+              "status": "acknowledged",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-02T00:00:00Z"
+            }
+            """)
+        }
+
+        let updated = try await mock.client.updateCveStatusByArtifactCve(
+            artifactId: "art-1",
+            cveId: "CVE-2024-9999",
+            status: "acknowledged",
+            reason: "investigated"
+        )
+
+        #expect(recorder.paths.contains("/api/v1/sbom/cve/status/by-artifact/art-1/by-cve/CVE-2024-9999"))
+        #expect(methodBox.methods.contains("POST"))
+        #expect(updated.status == "acknowledged")
+        #expect(bodyBox.bodies.first?.contains("acknowledged") == true)
+        #expect(bodyBox.bodies.first?.contains("investigated") == true)
+    }
+}
+
+/// Records request body strings across a sequence of requests.
+final class BodyRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _bodies: [String] = []
+    func record(_ body: String) {
+        lock.lock(); defer { lock.unlock() }
+        _bodies.append(body)
+    }
+    var bodies: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return _bodies
+    }
+
+    static func readStream(_ stream: InputStream) -> String {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let size = 4096
+        var buffer = [UInt8](repeating: 0, count: size)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: size)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
 }
 
 /// Records the HTTP methods seen across a sequence of requests.


### PR DESCRIPTION
## Summary
Cluster 5a + 5b. Tapping a CVE history row in the CVEs tab now opens a detail screen.

- The row is a NavigationLink into a new `CveHistoryDetailView`; on `.task` it re-fetches the single record by id via `getCveHistory(id:)` (`GET /api/v1/sbom/cve/history/{id}`) and renders the fetched value. This gives `get_cve_history` a real UI surface for the first time (it was API-only before, which the #68 gate flagged as overclaimed).
- A Set Status section offers a picker (open / acknowledged / false_positive / fixed) plus an optional reason, calling `updateCveStatusByArtifactCve` (`POST /api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id}`) with the artifact id and cve id taken from the fetched record at runtime. Matches the Android operate action (#95) for parity.

Raw-request style matching `CveHistoryView`/`SbomView`, with an `UpdateCveStatusRequest` model and a `label` affordance on the existing `CveStatus` enum. The CVE id in the row is now plain text (the NVD link moved into the detail) to avoid a nested-tap conflict with the NavigationLink.

### Resolved ops
- `get_cve_history` (now UI-wired, not just API)
- `update_cve_status_by_artifact_cve`

### Note on overlap with #76
PR #76 implements the same two ops with an equivalent approach. Cluster 5 was reassigned to me, so I built this off current main. **The orchestrator should merge exactly one of #76 or this and close the other** — they should not both land. This PR is built off the latest main (#74) and is green; #76 is older. Happy to defer to #76 if you prefer it.

### 5c / 5d
`get_repo_health` and `get_artifact_health` (cluster 5c/5d) are already merged in #72 with UI + tests; nothing rebuilt here.

Closes #81
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New path-pinning test `updateCveStatusTargetsByArtifactByCvePath` drives the real `updateCveStatusByArtifactCve` method through a per-instance `MockSession` and asserts the path, POST method, and request body. `get_cve_history` was already pinned by `getCveHistoryTargetsHistoryByIdPath`. Full suite green: 493 tests.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements