### PR TITLE
feat(ios): repository access tokens (list/create/get/revoke)

### DIFF
--- a/ArtifactKeeper.xcodeproj/project.pbxproj
+++ b/ArtifactKeeper.xcodeproj/project.pbxproj
@@ -101,11 +101,13 @@
 		661675A6E9DC360473BAA181 /* ArtifactDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE2C5256F844F6279846227 /* ArtifactDetail.swift */; };
 		66342C499ECF4ADDCCF83FFC /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341E812182C7DEF2DE15BDE6 /* AuthManager.swift */; };
 		67018A342717D2F56ADA6F58 /* TOTPVerificationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E81B31BCEB8455ABE51CD8D /* TOTPVerificationViewTests.swift */; };
+		68E83E7F4B36E0E10E8DEFAD /* RepoTokensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDB3E2C8A9265503ACBEC00 /* RepoTokensView.swift */; };
 		6D02C2A0C45C6E1D0AA70FE2 /* HealthDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AB45AA08A0DE4EA42BC041 /* HealthDashboardView.swift */; };
 		6D8FA2A9093D692547570860 /* KeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB8A8A8F6AD6C323EAF2022 /* KeychainManagerTests.swift */; };
 		706149420AF74CC3C2F55FDB /* PoliciesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387B1308AF0F0D5F5C768F13 /* PoliciesView.swift */; };
 		71DE9560CF0DC604499711B9 /* ServerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */; };
 		71FC30A34A235CFE53B1D1DF /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F289613B7B5E1B85C3F9E832 /* ArtifactDetailView.swift */; };
+		72090C495549EA95D88EB679 /* RepoTokensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDB3E2C8A9265503ACBEC00 /* RepoTokensView.swift */; };
 		738EFB98489D855A1E2FFE8B /* SetupInstructionsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F4BB814BCEC4170B1CA727 /* SetupInstructionsViewTests.swift */; };
 		76A035773BD7C7A5065F5E65 /* ServerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */; };
 		7795B1C86E7E5530C0ECA6BE /* SbomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACFAEE53DF20945E710A82E /* SbomView.swift */; };
@@ -147,6 +149,7 @@
 		9DE03A85868EB62612D588DC /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */; };
 		9F313A124D557820A4F7F737 /* RepoSecurityConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */; };
 		9FBBA3D5EAF49575952C78AD /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = F35A063FFE69F8B8A3CD7AEE /* OpenAPIURLSession */; };
+		A0E287A657FD7E9D70925A50 /* RepoToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A519889F51ED6EE8565F5A /* RepoToken.swift */; };
 		A1A538DE905D6AF031923CF5 /* AuthManagerExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BB213946F6067DE4267BAB /* AuthManagerExtendedTests.swift */; };
 		A481D0536AA2B6EEBA080174 /* QualityGatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFF1C0C6841D1BF61141BD7 /* QualityGatesView.swift */; };
 		A563ADC6B11F45AB50692ABA /* ScanConfigsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB7AD8D8492E7570FDE8A66 /* ScanConfigsView.swift */; };
@@ -173,6 +176,7 @@
 		B88EC39592199C1C4E1FB621 /* PackagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C67E4A61ED479E094891F7 /* PackagesView.swift */; };
 		BCD82AAFB0CAB353C5CABAD2 /* RepositoryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862E1C3205340290276A9B75 /* RepositoryTree.swift */; };
 		BF54F129B023787CC9A44249 /* SecurityMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF4590E6775407858BBAC86 /* SecurityMappingTests.swift */; };
+		BFCCDACF133F0A2A57BD7EB0 /* RepoToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A519889F51ED6EE8565F5A /* RepoToken.swift */; };
 		C003F153FD58DC40599D6AA3 /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9050B925E8CDAB492ED01C01 /* AnalyticsView.swift */; };
 		C0067BC56E14F7597CD91596 /* IntegrationSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADAC51BA77982E3BBFB4403 /* IntegrationSectionView.swift */; };
 		C02053BA07DD2669117F0E0C /* StagingSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846E4EAE3F90ADE47BE07930 /* StagingSectionView.swift */; };
@@ -192,6 +196,7 @@
 		D36FF1BE98A8940CC8E38C27 /* DependencyTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3514BB30D4591F702FE3C8B /* DependencyTrack.swift */; };
 		D40943078196189E5E593C67 /* SDKClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974C4288C3D5E8B4C3A1D76E /* SDKClient.swift */; };
 		D40F5A35411ACBE8737D54F7 /* ReplicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8067728F7917AD61F0DB4037 /* ReplicationView.swift */; };
+		D4A6CAF3C08F65C6F65E6BA3 /* RepoTokenPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18944166743D27AE399CF9C /* RepoTokenPathTests.swift */; };
 		D6794B241227A7A33DE011F3 /* ArtifactKeeperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D217BC8D6B2994A881C4E04E /* ArtifactKeeperApp.swift */; };
 		D6F8DEBE6DBFB0A7A1F1EB1F /* APIPathRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8D4619ABD35F3059816534 /* APIPathRegressionTests.swift */; };
 		D7AD6E41B44AF34DF7994C57 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81FFEFE5A4DE0397D840007 /* KeychainManager.swift */; };
@@ -203,6 +208,7 @@
 		DF321600060A4DA7993785FF /* Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBE59905B179E64919791A7 /* Admin.swift */; };
 		DF3A3118CF4C5C19CDC19B56 /* VirtualMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F508C0FBF498EB51BC64EE /* VirtualMember.swift */; };
 		E15A1D5EA6FDA4D8DAF42CF7 /* QualityMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8211F9D04C3BF74AB42324D9 /* QualityMappingTests.swift */; };
+		E186301880C191C66D1775AB /* RepoTokenPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18944166743D27AE399CF9C /* RepoTokenPathTests.swift */; };
 		E18E74AC77451E6C0022B276 /* Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBE59905B179E64919791A7 /* Admin.swift */; };
 		E2678146D7F808D22B485573 /* SecurityDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */; };
 		E4618623F8473A8661B7CC6F /* ChangePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7812397531D2CD01F4488BC6 /* ChangePasswordView.swift */; };
@@ -259,6 +265,8 @@
 		26DD24CE59A14232D46D4665 /* InstallPluginFromGitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallPluginFromGitView.swift; sourceTree = "<group>"; };
 		26F832901A43DC98CC288AA4 /* ArtifactSecurityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSecurityView.swift; sourceTree = "<group>"; };
 		28281FCD705C9F9F4DF23AF7 /* Quality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quality.swift; sourceTree = "<group>"; };
+		28A519889F51ED6EE8565F5A /* RepoToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoToken.swift; sourceTree = "<group>"; };
+		2BDB3E2C8A9265503ACBEC00 /* RepoTokensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoTokensView.swift; sourceTree = "<group>"; };
 		3412EF9765589F0F5C9613ED /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		341E812182C7DEF2DE15BDE6 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		36F508C0FBF498EB51BC64EE /* VirtualMember.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMember.swift; sourceTree = "<group>"; };
@@ -337,6 +345,7 @@
 		D5AB45AA08A0DE4EA42BC041 /* HealthDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthDashboardView.swift; sourceTree = "<group>"; };
 		DC2FE890E60756D1FFA94CD1 /* ArtifactKeeper.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ArtifactKeeper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0A9848E2DD8A8070E5CBBDC /* ServerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerManager.swift; sourceTree = "<group>"; };
+		E18944166743D27AE399CF9C /* RepoTokenPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoTokenPathTests.swift; sourceTree = "<group>"; };
 		E59705D3B5F2000ACABB8A48 /* Auth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Auth.swift; sourceTree = "<group>"; };
 		E6A527DEEF9DECA3F2E8EC26 /* AccountToolbarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountToolbarModifier.swift; sourceTree = "<group>"; };
 		E6D532EA4136F5C5CF5548AE /* WebhookPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookPathTests.swift; sourceTree = "<group>"; };
@@ -402,6 +411,7 @@
 				746DB83A1B571F5CDFDD791E /* RepoSecurityConfigView.swift */,
 				9688E0041F1683C5DDFA6071 /* RepositoriesView.swift */,
 				7FEF3A0FA55ECC63DDC8899F /* RepositoryDetailTabbedView.swift */,
+				2BDB3E2C8A9265503ACBEC00 /* RepoTokensView.swift */,
 				76C1CC3C4956018E653EC486 /* RepoUploadView.swift */,
 				113DC09E3B0845FAD9BDA8F6 /* SetupInstructionsView.swift */,
 				5897003BAFB18AFF0865CCEC /* VirtualMembersView.swift */,
@@ -435,6 +445,7 @@
 				4147C420ECCBB9137917722C /* PluginPathTests.swift */,
 				8211F9D04C3BF74AB42324D9 /* QualityMappingTests.swift */,
 				435C7C6ACC4028C205301D14 /* RepositoryTreeTests.swift */,
+				E18944166743D27AE399CF9C /* RepoTokenPathTests.swift */,
 				F8A6FF4BFFCF392A815F6E11 /* SecurityDispatchTests.swift */,
 				CAF4590E6775407858BBAC86 /* SecurityMappingTests.swift */,
 				65F26A3F934E811A6A5B6FCF /* ServerManagerTests.swift */,
@@ -503,6 +514,7 @@
 				ADB0E30CAAF92793E9ED4168 /* RepoSecurityConfig.swift */,
 				75FB2391848A9D7A02E4F7DC /* Repository.swift */,
 				862E1C3205340290276A9B75 /* RepositoryTree.swift */,
+				28A519889F51ED6EE8565F5A /* RepoToken.swift */,
 				8DF4F010E1DD1DC5415E7F11 /* Sbom.swift */,
 				3D8118DAD8066C9D0EED317C /* Security.swift */,
 				36F508C0FBF498EB51BC64EE /* VirtualMember.swift */,
@@ -879,6 +891,7 @@
 				FD18CC2609F7FF5CA43A5EEC /* ModelTests.swift in Sources */,
 				293314A1B0346F707F5B3CE4 /* PluginPathTests.swift in Sources */,
 				E15A1D5EA6FDA4D8DAF42CF7 /* QualityMappingTests.swift in Sources */,
+				D4A6CAF3C08F65C6F65E6BA3 /* RepoTokenPathTests.swift in Sources */,
 				1A02AD83B2F212120BFC892A /* RepositoryTreeTests.swift in Sources */,
 				E2678146D7F808D22B485573 /* SecurityDispatchTests.swift in Sources */,
 				EC57A5F27A84651FE192BC0A /* SecurityMappingTests.swift in Sources */,
@@ -945,6 +958,8 @@
 				D40F5A35411ACBE8737D54F7 /* ReplicationView.swift in Sources */,
 				9F313A124D557820A4F7F737 /* RepoSecurityConfig.swift in Sources */,
 				4BE83BE4509F6A9FBAC7EA93 /* RepoSecurityConfigView.swift in Sources */,
+				BFCCDACF133F0A2A57BD7EB0 /* RepoToken.swift in Sources */,
+				72090C495549EA95D88EB679 /* RepoTokensView.swift in Sources */,
 				82D32C6CEE6B9A5386787EEF /* RepoUploadView.swift in Sources */,
 				CBA92159E5A5DFC00F6CBC28 /* RepositoriesView.swift in Sources */,
 				CB9F64C28FEBB032DD2210F6 /* Repository.swift in Sources */,
@@ -996,6 +1011,7 @@
 				83D01D48B7B7C3739E1344B3 /* ModelTests.swift in Sources */,
 				B18AAE17086834FBB57455D9 /* PluginPathTests.swift in Sources */,
 				868F52C07277B589BE29205D /* QualityMappingTests.swift in Sources */,
+				E186301880C191C66D1775AB /* RepoTokenPathTests.swift in Sources */,
 				4BA74F65F09BD28BC25CC705 /* RepositoryTreeTests.swift in Sources */,
 				2BBCC7E1EFC1A7A5C06BD188 /* SecurityDispatchTests.swift in Sources */,
 				BF54F129B023787CC9A44249 /* SecurityMappingTests.swift in Sources */,
@@ -1062,6 +1078,8 @@
 				475F7C0CA9365AB11D952814 /* ReplicationView.swift in Sources */,
 				B2BDDB70803CC764E1147668 /* RepoSecurityConfig.swift in Sources */,
 				B596C3D83FBAFD453E1E20DD /* RepoSecurityConfigView.swift in Sources */,
+				A0E287A657FD7E9D70925A50 /* RepoToken.swift in Sources */,
+				68E83E7F4B36E0E10E8DEFAD /* RepoTokensView.swift in Sources */,
 				8D14D0F52AF6E89139D3264B /* RepoUploadView.swift in Sources */,
 				3E092F89AC9B6CA6DC50DAEB /* RepositoriesView.swift in Sources */,
 				DD14915474376F9ECAB7D78B /* Repository.swift in Sources */,

--- a/ArtifactKeeper/Sources/Core/API/APIClient.swift
+++ b/ArtifactKeeper/Sources/Core/API/APIClient.swift
@@ -921,6 +921,46 @@ actor APIClient {
         )
     }
 
+    // MARK: Repository Tokens (raw requests)
+
+    /// List a repository's access tokens (GET /api/v1/repositories/{key}/tokens).
+    func listRepoTokens(repoKey: String) async throws -> [RepoToken] {
+        let encoded = repoKey.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? repoKey
+        let response: RepoTokenListResponse = try await request("/api/v1/repositories/\(encoded)/tokens")
+        return response.items
+    }
+
+    /// Fetch a single repository token (GET /api/v1/repositories/{key}/tokens/{token_id}).
+    func getRepoToken(repoKey: String, tokenId: String) async throws -> RepoToken {
+        let encoded = repoKey.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? repoKey
+        return try await request("/api/v1/repositories/\(encoded)/tokens/\(tokenId)")
+    }
+
+    /// Create a repository token (POST /api/v1/repositories/{key}/tokens). The
+    /// returned secret is only available in this response.
+    func createRepoToken(
+        repoKey: String,
+        name: String,
+        scopes: [String],
+        description: String? = nil,
+        expiresInDays: Int? = nil
+    ) async throws -> CreateRepoTokenResponse {
+        let encoded = repoKey.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? repoKey
+        let body = CreateRepoTokenRequest(
+            name: name,
+            scopes: scopes,
+            description: description,
+            expiresInDays: expiresInDays
+        )
+        return try await request("/api/v1/repositories/\(encoded)/tokens", method: "POST", body: body)
+    }
+
+    /// Revoke a repository token (DELETE /api/v1/repositories/{key}/tokens/{token_id}).
+    func revokeRepoToken(repoKey: String, tokenId: String) async throws {
+        let encoded = repoKey.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? repoKey
+        try await requestVoid("/api/v1/repositories/\(encoded)/tokens/\(tokenId)", method: "DELETE")
+    }
+
     // MARK: - Date Formatting Helper
 
     nonisolated static func formatDate(_ date: Foundation.Date) -> String {

--- a/ArtifactKeeper/Sources/Core/Models/RepoToken.swift
+++ b/ArtifactKeeper/Sources/Core/Models/RepoToken.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+// MARK: - Repository Tokens (1.2.1 /api/v1/repositories/{key}/tokens)
+
+/// A repository-scoped access token (list/get). The secret value is only
+/// returned once at creation; list/get expose just the prefix.
+struct RepoToken: Codable, Identifiable, Sendable {
+    let id: String
+    let name: String
+    let description: String?
+    let tokenPrefix: String
+    let scopes: [String]
+    let createdAt: String
+    let createdBy: String?
+    let expiresAt: String?
+    let lastUsedAt: String?
+    let isExpired: Bool
+    let isRevoked: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, description, scopes
+        case tokenPrefix = "token_prefix"
+        case createdAt = "created_at"
+        case createdBy = "created_by"
+        case expiresAt = "expires_at"
+        case lastUsedAt = "last_used_at"
+        case isExpired = "is_expired"
+        case isRevoked = "is_revoked"
+    }
+}
+
+struct RepoTokenListResponse: Codable, Sendable {
+    let items: [RepoToken]
+}
+
+/// Body for POST /api/v1/repositories/{key}/tokens.
+struct CreateRepoTokenRequest: Encodable {
+    let name: String
+    let scopes: [String]
+    let description: String?
+    let expiresInDays: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case name, scopes, description
+        case expiresInDays = "expires_in_days"
+    }
+}
+
+/// Response from creating a token. The `token` secret is shown only here.
+struct CreateRepoTokenResponse: Codable, Sendable {
+    let id: String
+    let name: String
+    let token: String
+    let repositoryKey: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, token
+        case repositoryKey = "repository_key"
+    }
+}

--- a/ArtifactKeeper/Sources/Features/Repositories/RepoTokensView.swift
+++ b/ArtifactKeeper/Sources/Features/Repositories/RepoTokensView.swift
@@ -1,0 +1,296 @@
+import SwiftUI
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
+/// Repository-scoped access tokens for a single repository
+/// (/api/v1/repositories/{key}/tokens). Lists tokens, creates a new one (the
+/// secret is shown once), and revokes a token behind a confirmation.
+struct RepoTokensView: View {
+    let repoKey: String
+
+    @State private var tokens: [RepoToken] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    @State private var showCreate = false
+    @State private var createdToken: CreateRepoTokenResponse?
+    @State private var tokenToRevoke: RepoToken?
+    @State private var isRevoking = false
+
+    private let apiClient = APIClient.shared
+
+    var body: some View {
+        List {
+            if let createdToken {
+                Section("New Token Created") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Copy this token now \u{2014} it will not be shown again.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(createdToken.token)
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                        Button {
+                            copyToClipboard(createdToken.token)
+                        } label: {
+                            Label("Copy Token", systemImage: "doc.on.doc")
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+
+            Section {
+                if isLoading {
+                    ProgressView()
+                } else if let errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if tokens.isEmpty {
+                    ContentUnavailableView(
+                        "No Tokens",
+                        systemImage: "key",
+                        description: Text("Create a token for programmatic access to this repository.")
+                    )
+                } else {
+                    ForEach(tokens) { token in
+                        RepoTokenRow(token: token) {
+                            tokenToRevoke = token
+                        }
+                    }
+                }
+            } header: {
+                HStack {
+                    Text("Repository Tokens")
+                    Spacer()
+                    Button {
+                        showCreate = true
+                    } label: {
+                        Label("Create", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+        }
+        .refreshable { await load() }
+        .task { await load() }
+        .sheet(isPresented: $showCreate) {
+            NavigationStack {
+                CreateRepoTokenView(repoKey: repoKey) { created in
+                    createdToken = created
+                    await load()
+                }
+            }
+        }
+        .confirmationDialog(
+            "Revoke \(tokenToRevoke?.name ?? "token")?",
+            isPresented: Binding(
+                get: { tokenToRevoke != nil },
+                set: { if !$0 { tokenToRevoke = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Revoke", role: .destructive) {
+                if let token = tokenToRevoke {
+                    Task { await revoke(token) }
+                }
+            }
+            Button("Cancel", role: .cancel) { tokenToRevoke = nil }
+        } message: {
+            Text("Revoking immediately disables this token. This cannot be undone.")
+        }
+    }
+
+    private func load() async {
+        isLoading = tokens.isEmpty
+        do {
+            tokens = try await apiClient.listRepoTokens(repoKey: repoKey)
+            errorMessage = nil
+        } catch {
+            if tokens.isEmpty {
+                errorMessage = "Could not load tokens. You may need admin privileges."
+            }
+        }
+        isLoading = false
+    }
+
+    private func revoke(_ token: RepoToken) async {
+        isRevoking = true
+        defer { isRevoking = false; tokenToRevoke = nil }
+        do {
+            try await apiClient.revokeRepoToken(repoKey: repoKey, tokenId: token.id)
+            await load()
+        } catch {
+            errorMessage = "Failed to revoke \(token.name): \(error.localizedDescription)"
+        }
+    }
+
+    private func copyToClipboard(_ value: String) {
+        #if os(iOS)
+        UIPasteboard.general.string = value
+        #elseif os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+        #endif
+    }
+}
+
+private struct RepoTokenRow: View {
+    let token: RepoToken
+    let onRevoke: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(token.name).font(.headline)
+                if token.isRevoked {
+                    statusTag("Revoked", .red)
+                } else if token.isExpired {
+                    statusTag("Expired", .orange)
+                }
+                Spacer()
+                if !token.isRevoked {
+                    Button(role: .destructive, action: onRevoke) {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+            Text(token.tokenPrefix + "\u{2026}")
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+            if !token.scopes.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(token.scopes, id: \.self) { scope in
+                        Text(scope)
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(.secondary.opacity(0.15), in: Capsule())
+                    }
+                }
+            }
+            if let expiresAt = token.expiresAt {
+                Text("Expires \(formattedDate(expiresAt))")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+
+    private func statusTag(_ text: String, _ color: Color) -> some View {
+        Text(text)
+            .font(.caption2.weight(.bold))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15), in: Capsule())
+            .foregroundStyle(color)
+    }
+}
+
+/// Create-token sheet: name, scopes, expiry.
+private struct CreateRepoTokenView: View {
+    let repoKey: String
+    let onCreated: (CreateRepoTokenResponse) async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var scopes: Set<String> = ["read"]
+    @State private var expiryDays = 90
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+
+    private let apiClient = APIClient.shared
+    private let availableScopes = ["read", "write", "delete", "admin"]
+    private let expiryOptions: [(String, Int)] = [
+        ("30 days", 30), ("90 days", 90), ("180 days", 180), ("1 year", 365), ("Never", 0),
+    ]
+
+    var body: some View {
+        Form {
+            Section("Token") {
+                TextField("Name", text: $name)
+                    #if os(iOS)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                    #endif
+            }
+
+            Section("Scopes") {
+                ForEach(availableScopes, id: \.self) { scope in
+                    Toggle(scope.capitalized, isOn: Binding(
+                        get: { scopes.contains(scope) },
+                        set: { on in
+                            if on { scopes.insert(scope) } else { scopes.remove(scope) }
+                        }
+                    ))
+                }
+            }
+
+            Section("Expiry") {
+                Picker("Expires", selection: $expiryDays) {
+                    ForEach(expiryOptions, id: \.1) { option in
+                        Text(option.0).tag(option.1)
+                    }
+                }
+            }
+
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
+            }
+        }
+        .navigationTitle("Create Token")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+                    .disabled(isCreating)
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Create") { Task { await create() } }
+                    .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty || scopes.isEmpty || isCreating)
+            }
+        }
+    }
+
+    private func create() async {
+        isCreating = true
+        errorMessage = nil
+        defer { isCreating = false }
+        do {
+            let result = try await apiClient.createRepoToken(
+                repoKey: repoKey,
+                name: name.trimmingCharacters(in: .whitespaces),
+                scopes: Array(scopes).sorted(),
+                expiresInDays: expiryDays == 0 ? nil : expiryDays
+            )
+            await onCreated(result)
+            dismiss()
+        } catch {
+            errorMessage = "Could not create token: \(error.localizedDescription)"
+        }
+    }
+}
+
+private func formattedDate(_ dateString: String) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = formatter.date(from: dateString) {
+        let display = DateFormatter()
+        display.dateStyle = .medium
+        return display.string(from: date)
+    }
+    return dateString
+}

--- a/ArtifactKeeper/Sources/Features/Repositories/RepositoryDetailTabbedView.swift
+++ b/ArtifactKeeper/Sources/Features/Repositories/RepositoryDetailTabbedView.swift
@@ -29,6 +29,7 @@ struct RepositoryDetailTabbedView: View {
         }
         if authManager.currentUser?.isAdmin == true {
             tabs.append(("security", "Security"))
+            tabs.append(("tokens", "Tokens"))
         }
         return tabs
     }
@@ -196,6 +197,8 @@ struct RepositoryDetailTabbedView: View {
             VirtualMembersView(repoKey: repoKey)
         case "security":
             RepoSecurityConfigView(repoKey: repoKey)
+        case "tokens":
+            RepoTokensView(repoKey: repoKey)
         default:
             EmptyView()
         }

--- a/ArtifactKeeper/Tests/RepoTokenPathTests.swift
+++ b/ArtifactKeeper/Tests/RepoTokenPathTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import ArtifactKeeper
+
+// Path-pinning tests for the raw-request repository-token methods on APIClient.
+// Each test drives the real production method through a per-instance MockSession
+// (isolated handler, parallel-safe) and asserts the outgoing request path and
+// method. A canned 200 body lets the method decode and return.
+
+@Suite("Repository Token Path Tests")
+struct RepoTokenPathTests {
+
+    private func okResponse(_ url: URL, _ body: String, status: Int = 200) -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+        return (response, Data(body.utf8))
+    }
+
+    private let tokenJSON = """
+    {
+      "id": "tok-1", "name": "ci", "token_prefix": "ak_abc",
+      "scopes": ["read"], "created_at": "2026-01-01T00:00:00Z",
+      "is_expired": false, "is_revoked": false
+    }
+    """
+
+    @Test func listRepoTokensTargetsTokensPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let recorder = PathRecorder()
+        mock.handler = { request in
+            recorder.record(request.url!.path)
+            return self.okResponse(request.url!, #"{"items":[]}"#)
+        }
+
+        _ = try await mock.client.listRepoTokens(repoKey: "maven-prod")
+
+        #expect(recorder.paths.contains("/api/v1/repositories/maven-prod/tokens"))
+    }
+
+    @Test func getRepoTokenTargetsTokenByIdPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let recorder = PathRecorder()
+        mock.handler = { request in
+            recorder.record(request.url!.path)
+            return self.okResponse(request.url!, self.tokenJSON)
+        }
+
+        let token = try await mock.client.getRepoToken(repoKey: "maven-prod", tokenId: "tok-1")
+
+        #expect(recorder.paths.contains("/api/v1/repositories/maven-prod/tokens/tok-1"))
+        #expect(token.id == "tok-1")
+    }
+
+    @Test func createRepoTokenTargetsTokensPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let recorder = PathRecorder()
+        let methodBox = MethodRecorder()
+        mock.handler = { request in
+            recorder.record(request.url!.path)
+            methodBox.record(request.httpMethod ?? "")
+            return self.okResponse(request.url!, """
+            {"id":"tok-9","name":"ci","token":"ak_secret","repository_key":"maven-prod"}
+            """, status: 201)
+        }
+
+        let result = try await mock.client.createRepoToken(
+            repoKey: "maven-prod",
+            name: "ci",
+            scopes: ["read", "write"],
+            expiresInDays: 90
+        )
+
+        #expect(recorder.paths.contains("/api/v1/repositories/maven-prod/tokens"))
+        #expect(methodBox.methods.contains("POST"))
+        #expect(result.token == "ak_secret")
+    }
+
+    @Test func revokeRepoTokenTargetsTokenByIdPath() async throws {
+        let mock = MockSession(baseURL: "https://test-api.example.com")
+        let recorder = PathRecorder()
+        let methodBox = MethodRecorder()
+        mock.handler = { request in
+            recorder.record(request.url!.path)
+            methodBox.record(request.httpMethod ?? "")
+            return self.okResponse(request.url!, "")
+        }
+
+        try await mock.client.revokeRepoToken(repoKey: "maven-prod", tokenId: "tok-7")
+
+        #expect(recorder.paths.contains("/api/v1/repositories/maven-prod/tokens/tok-7"))
+        #expect(methodBox.methods.contains("DELETE"))
+    }
+}


### PR DESCRIPTION
## Summary
Adds a **Tokens** tab to the repository detail (admin-only) for managing repository-scoped access tokens.

- Lists tokens (`GET /api/v1/repositories/{key}/tokens`) with prefix, scopes, expiry, and revoked/expired status badges.
- Create opens a sheet (name + scope toggles + expiry picker) calling `POST .../tokens`; the returned secret is shown once in a "New Token Created" section with a copy button (it is never shown again).
- Revoke (`DELETE .../tokens/{token_id}`) is behind a confirmation dialog.
- `getRepoToken` (`GET .../tokens/{token_id}`) is wired for single-record fetch.

Raw-request style matching the existing repo-config and Profile API-key surfaces, with `RepoToken` / `CreateRepoTokenRequest` / `CreateRepoTokenResponse` models. Cross-platform clipboard copy (UIKit/AppKit).

### Resolved ops
- `list_repo_tokens`, `create_repo_token`, `get_repo_token`, `revoke_repo_token`

### Deferred
- None for this cluster.

Closes #83
Part of #40

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Path-pinning tests drive the real `listRepoTokens` / `getRepoToken` / `createRepoToken` / `revokeRepoToken` methods through per-instance `MockSession` handlers and assert the path and HTTP method (incl. POST body / DELETE). Full suite green: 496 tests.

## Platform
- [ ] Tested on iOS simulator
- [x] Tested on macOS
- [ ] SwiftUI previews render correctly
- [x] Accessibility labels present on interactive elements